### PR TITLE
Temporary solution to fix tautology (ru_ru.json)

### DIFF
--- a/src/main/resources/assets/yet-another-config-lib/lang/ru_ru.json
+++ b/src/main/resources/assets/yet-another-config-lib/lang/ru_ru.json
@@ -15,7 +15,7 @@
     "yacl.gui.fail_apply.tooltip": "Возникла ошибка; изменения невозможно применить.",
     "yacl.gui.save_before_exit": "Сохраните перед закрытием",
     "yacl.gui.save_before_exit.tooltip": "Сохраните или отмените изменения, чтобы закрыть настройки.",
- 
+
     "yacl.restart.title": "Настройки требуют перезагрузки.",
     "yacl.restart.message": "Одна или несколько настроек требует перезапуска игры для применения изменений.",
     "yacl.restart.yes": "Закрыть Minecraft",

--- a/src/main/resources/assets/yet-another-config-lib/lang/ru_ru.json
+++ b/src/main/resources/assets/yet-another-config-lib/lang/ru_ru.json
@@ -1,18 +1,21 @@
 {
     "yacl.control.boolean.true": "§atrue",
     "yacl.control.boolean.false": "§cfalse",
+
     "yacl.control.action.execute": "Выполнить",
+
     "yacl.gui.save": "Сохранить",
     "yacl.gui.save.tooltip": "Сохранить изменения до следующего редактирования.",
     "yacl.gui.finished.tooltip": "Закрыть меню.",
     "yacl.gui.cancel.tooltip": "Отменить изменения и закрыть настройки.",
     "yacl.gui.reset.tooltip": "Сбросить все настройки до значений по умолчанию (это можно отменить).",
-    "yacl.gui.undo": "Отменить",
+    "yacl.gui.undo": "Восстановить",
     "yacl.gui.undo.tooltip": "Вернуть все настройки к состоянию, в котором они были до изменений.",
     "yacl.gui.fail_apply": "Не удалось применить изменения",
     "yacl.gui.fail_apply.tooltip": "Возникла ошибка; изменения невозможно применить.",
     "yacl.gui.save_before_exit": "Сохраните перед закрытием",
     "yacl.gui.save_before_exit.tooltip": "Сохраните или отмените изменения, чтобы закрыть настройки.",
+ 
     "yacl.restart.title": "Настройки требуют перезагрузки.",
     "yacl.restart.message": "Одна или несколько настроек требует перезапуска игры для применения изменений.",
     "yacl.restart.yes": "Закрыть Minecraft",


### PR DESCRIPTION
Temporary solution until #21 is resolved, fixes this:
![Снимок экрана 2022-09-26 001917](https://user-images.githubusercontent.com/75726196/192166513-d513204a-4de8-4cf3-adbe-0b77edb91c28.png)

Still not as good as if `Cancel` would be localized as `Назад` (raw translation is `Back`), but quite acceptable.