### PR TITLE
Small improvements to ListOption

### DIFF
--- a/common/src/main/java/dev/isxander/yacl3/api/ListOption.java
+++ b/common/src/main/java/dev/isxander/yacl3/api/ListOption.java
@@ -30,6 +30,15 @@ public interface ListOption<T> extends OptionGroup, Option<List<T>> {
     @NotNull ImmutableList<ListOptionEntry<T>> options();
 
     @ApiStatus.Internal
+    int numberOfEntries();
+
+    @ApiStatus.Internal
+    int maximumNumberOfEntries();
+
+    @ApiStatus.Internal
+    int minimumNumberOfEntries();
+
+    @ApiStatus.Internal
     ListOptionEntry<T> insertNewEntryToTop();
 
     @ApiStatus.Internal
@@ -104,6 +113,18 @@ public interface ListOption<T> extends OptionGroup, Option<List<T>> {
          * @see Option#available()
          */
         Builder<T> available(boolean available);
+
+        /**
+         * Sets a minimum size for the list. Once this size is reached,
+         * no further entries may be removed.
+         */
+        Builder<T> minimumNumberOfEntries(int number);
+
+        /**
+         * Sets a maximum size for the list. Once this size is reached,
+         * no further entries may be added.
+         */
+        Builder<T> maximumNumberOfEntries(int number);
 
         /**
          * Adds a flag to the option.

--- a/common/src/main/java/dev/isxander/yacl3/api/ListOption.java
+++ b/common/src/main/java/dev/isxander/yacl3/api/ListOption.java
@@ -39,7 +39,7 @@ public interface ListOption<T> extends OptionGroup, Option<List<T>> {
     int minimumNumberOfEntries();
 
     @ApiStatus.Internal
-    ListOptionEntry<T> insertNewEntryToTop();
+    ListOptionEntry<T> insertNewEntry();
 
     @ApiStatus.Internal
     void insertEntry(int index, ListOptionEntry<?> entry);
@@ -125,6 +125,12 @@ public interface ListOption<T> extends OptionGroup, Option<List<T>> {
          * no further entries may be added.
          */
         Builder<T> maximumNumberOfEntries(int number);
+
+        /**
+         * Dictates if new entries should be added to the end of the list
+         * rather than the top.
+         */
+        Builder<T> insertEntriesAtEnd(boolean insertAtEnd);
 
         /**
          * Adds a flag to the option.

--- a/common/src/main/java/dev/isxander/yacl3/gui/OptionListWidget.java
+++ b/common/src/main/java/dev/isxander/yacl3/gui/OptionListWidget.java
@@ -485,7 +485,7 @@ public class OptionListWidget extends ElementListWidgetExt<OptionListWidget.Entr
 
 
             this.addListButton = new TooltipButtonWidget(yaclScreen, resetListButton.getX() - 20, -50, 20, 20, Component.literal("+"), Component.translatable("yacl.list.add_top"), btn -> {
-                group.insertNewEntryToTop();
+                group.insertNewEntry();
                 setExpanded(true);
             });
 

--- a/common/src/main/java/dev/isxander/yacl3/gui/OptionListWidget.java
+++ b/common/src/main/java/dev/isxander/yacl3/gui/OptionListWidget.java
@@ -519,7 +519,7 @@ public class OptionListWidget extends ElementListWidgetExt<OptionListWidget.Entr
             super.updateExpandMinimizeText();
             expandMinimizeButton.active = listOption == null || listOption.available();
             if (addListButton != null)
-                addListButton.active = expandMinimizeButton.active;
+                addListButton.active = expandMinimizeButton.active && listOption.numberOfEntries() < listOption.maximumNumberOfEntries();
         }
 
         @Override

--- a/common/src/main/java/dev/isxander/yacl3/gui/controllers/ListEntryWidget.java
+++ b/common/src/main/java/dev/isxander/yacl3/gui/controllers/ListEntryWidget.java
@@ -80,7 +80,7 @@ public class ListEntryWidget extends AbstractWidget implements ContainerEventHan
     }
 
     protected void updateButtonStates() {
-        removeButton.active = listOption.available();
+        removeButton.active = listOption.available() && listOption.numberOfEntries() > listOption.minimumNumberOfEntries();
         moveUpButton.active = listOption.indexOf(listOptionEntry) > 0 && listOption.available();
         moveDownButton.active = listOption.indexOf(listOptionEntry) < listOption.options().size() - 1 && listOption.available();
     }

--- a/common/src/main/java/dev/isxander/yacl3/impl/ListOptionImpl.java
+++ b/common/src/main/java/dev/isxander/yacl3/impl/ListOptionImpl.java
@@ -27,12 +27,13 @@ public final class ListOptionImpl<T> implements ListOption<T> {
     private boolean available;
     private final int minimumNumberOfEntries;
     private final int maximumNumberOfEntries;
+    private final boolean insertEntriesAtEnd;
     private final ImmutableSet<OptionFlag> flags;
     private final EntryFactory entryFactory;
     private final List<BiConsumer<Option<List<T>>, List<T>>> listeners;
     private final List<Runnable> refreshListeners;
 
-    public ListOptionImpl(@NotNull Component name, @NotNull OptionDescription description, @NotNull Binding<List<T>> binding, @NotNull T initialValue, @NotNull Function<ListOptionEntry<T>, Controller<T>> controllerFunction, ImmutableSet<OptionFlag> flags, boolean collapsed, boolean available, int minimumNumberOfEntries, int maximumNumberOfEntries, Collection<BiConsumer<Option<List<T>>, List<T>>> listeners) {
+    public ListOptionImpl(@NotNull Component name, @NotNull OptionDescription description, @NotNull Binding<List<T>> binding, @NotNull T initialValue, @NotNull Function<ListOptionEntry<T>, Controller<T>> controllerFunction, ImmutableSet<OptionFlag> flags, boolean collapsed, boolean available, int minimumNumberOfEntries, int maximumNumberOfEntries, boolean insertEntriesAtEnd, Collection<BiConsumer<Option<List<T>>, List<T>>> listeners) {
         this.name = name;
         this.description = description;
         this.binding = binding;
@@ -44,6 +45,7 @@ public final class ListOptionImpl<T> implements ListOption<T> {
         this.available = available;
         this.minimumNumberOfEntries = minimumNumberOfEntries;
         this.maximumNumberOfEntries = maximumNumberOfEntries;
+        this.insertEntriesAtEnd = insertEntriesAtEnd;
         this.listeners = new ArrayList<>();
         this.listeners.addAll(listeners);
         this.refreshListeners = new ArrayList<>();
@@ -102,9 +104,14 @@ public final class ListOptionImpl<T> implements ListOption<T> {
     }
 
     @Override
-    public ListOptionEntry<T> insertNewEntryToTop() {
+    public ListOptionEntry<T> insertNewEntry() {
         ListOptionEntry<T> newEntry = entryFactory.create(initialValue);
-        entries.add(0, newEntry);
+        if (insertEntriesAtEnd) {
+            entries.add(newEntry);
+        } else {
+            // insert at top
+            entries.add(0, newEntry);
+        }
         onRefresh();
         return newEntry;
     }
@@ -232,6 +239,7 @@ public final class ListOptionImpl<T> implements ListOption<T> {
         private boolean available = true;
         private int minimumNumberOfEntries = 0;
         private int maximumNumberOfEntries = Integer.MAX_VALUE;
+        private boolean insertEntriesAtEnd = false;
         private final List<BiConsumer<Option<List<T>>, List<T>>> listeners = new ArrayList<>();
 
         @Override
@@ -311,6 +319,12 @@ public final class ListOptionImpl<T> implements ListOption<T> {
         }
 
         @Override
+        public Builder<T> insertEntriesAtEnd(boolean insertAtEnd) {
+            this.insertEntriesAtEnd = insertAtEnd;
+            return this;
+        }
+
+        @Override
         public Builder<T> flag(@NotNull OptionFlag... flag) {
             Validate.notNull(flag, "`flag` must not be null");
 
@@ -350,7 +364,7 @@ public final class ListOptionImpl<T> implements ListOption<T> {
             Validate.notNull(binding, "`binding` must not be null");
             Validate.notNull(initialValue, "`initialValue` must not be null");
 
-            return new ListOptionImpl<>(name, description, binding, initialValue, controllerFunction, ImmutableSet.copyOf(flags), collapsed, available, minimumNumberOfEntries, maximumNumberOfEntries, listeners);
+            return new ListOptionImpl<>(name, description, binding, initialValue, controllerFunction, ImmutableSet.copyOf(flags), collapsed, available, minimumNumberOfEntries, maximumNumberOfEntries, insertEntriesAtEnd, listeners);
         }
     }
 }

--- a/common/src/main/java/dev/isxander/yacl3/impl/ListOptionImpl.java
+++ b/common/src/main/java/dev/isxander/yacl3/impl/ListOptionImpl.java
@@ -25,12 +25,14 @@ public final class ListOptionImpl<T> implements ListOption<T> {
     private final List<ListOptionEntry<T>> entries;
     private final boolean collapsed;
     private boolean available;
+    private final int minimumNumberOfEntries;
+    private final int maximumNumberOfEntries;
     private final ImmutableSet<OptionFlag> flags;
     private final EntryFactory entryFactory;
     private final List<BiConsumer<Option<List<T>>, List<T>>> listeners;
     private final List<Runnable> refreshListeners;
 
-    public ListOptionImpl(@NotNull Component name, @NotNull OptionDescription description, @NotNull Binding<List<T>> binding, @NotNull T initialValue, @NotNull Function<ListOptionEntry<T>, Controller<T>> controllerFunction, ImmutableSet<OptionFlag> flags, boolean collapsed, boolean available, Collection<BiConsumer<Option<List<T>>, List<T>>> listeners) {
+    public ListOptionImpl(@NotNull Component name, @NotNull OptionDescription description, @NotNull Binding<List<T>> binding, @NotNull T initialValue, @NotNull Function<ListOptionEntry<T>, Controller<T>> controllerFunction, ImmutableSet<OptionFlag> flags, boolean collapsed, boolean available, int minimumNumberOfEntries, int maximumNumberOfEntries, Collection<BiConsumer<Option<List<T>>, List<T>>> listeners) {
         this.name = name;
         this.description = description;
         this.binding = binding;
@@ -40,6 +42,8 @@ public final class ListOptionImpl<T> implements ListOption<T> {
         this.collapsed = collapsed;
         this.flags = flags;
         this.available = available;
+        this.minimumNumberOfEntries = minimumNumberOfEntries;
+        this.maximumNumberOfEntries = maximumNumberOfEntries;
         this.listeners = new ArrayList<>();
         this.listeners.addAll(listeners);
         this.refreshListeners = new ArrayList<>();
@@ -163,6 +167,19 @@ public final class ListOptionImpl<T> implements ListOption<T> {
     }
 
     @Override
+    public int numberOfEntries() {
+        return this.entries.size();
+    }
+    @Override
+    public int maximumNumberOfEntries() {
+        return this.maximumNumberOfEntries;
+    }
+    @Override
+    public int minimumNumberOfEntries() {
+        return this.minimumNumberOfEntries;
+    }
+
+    @Override
     public void addListener(BiConsumer<Option<List<T>>, List<T>> changedListener) {
         this.listeners.add(changedListener);
     }
@@ -213,6 +230,8 @@ public final class ListOptionImpl<T> implements ListOption<T> {
         private T initialValue;
         private boolean collapsed = false;
         private boolean available = true;
+        private int minimumNumberOfEntries = 0;
+        private int maximumNumberOfEntries = Integer.MAX_VALUE;
         private final List<BiConsumer<Option<List<T>>, List<T>>> listeners = new ArrayList<>();
 
         @Override
@@ -280,6 +299,18 @@ public final class ListOptionImpl<T> implements ListOption<T> {
         }
 
         @Override
+        public Builder<T> minimumNumberOfEntries(int number) {
+            this.minimumNumberOfEntries = number;
+            return this;
+        }
+
+        @Override
+        public Builder<T> maximumNumberOfEntries(int number) {
+            this.maximumNumberOfEntries = number;
+            return this;
+        }
+
+        @Override
         public Builder<T> flag(@NotNull OptionFlag... flag) {
             Validate.notNull(flag, "`flag` must not be null");
 
@@ -319,7 +350,7 @@ public final class ListOptionImpl<T> implements ListOption<T> {
             Validate.notNull(binding, "`binding` must not be null");
             Validate.notNull(initialValue, "`initialValue` must not be null");
 
-            return new ListOptionImpl<>(name, description, binding, initialValue, controllerFunction, ImmutableSet.copyOf(flags), collapsed, available, listeners);
+            return new ListOptionImpl<>(name, description, binding, initialValue, controllerFunction, ImmutableSet.copyOf(flags), collapsed, available, minimumNumberOfEntries, maximumNumberOfEntries, listeners);
         }
     }
 }

--- a/test-common/src/main/java/dev/isxander/yacl3/test/GuiTest.java
+++ b/test-common/src/main/java/dev/isxander/yacl3/test/GuiTest.java
@@ -261,6 +261,8 @@ public class GuiTest {
                                         )
                                         .controller(StringControllerBuilder::create)
                                         .initial("")
+                                        .minimumNumberOfEntries(3)
+                                        .maximumNumberOfEntries(5)
                                         .build())
                                 .group(ListOption.<Integer>createBuilder()
                                         .name(Component.literal("Slider List"))

--- a/test-common/src/main/java/dev/isxander/yacl3/test/GuiTest.java
+++ b/test-common/src/main/java/dev/isxander/yacl3/test/GuiTest.java
@@ -263,6 +263,7 @@ public class GuiTest {
                                         .initial("")
                                         .minimumNumberOfEntries(3)
                                         .maximumNumberOfEntries(5)
+                                        .insertEntriesAtEnd(true)
                                         .build())
                                 .group(ListOption.<Integer>createBuilder()
                                         .name(Component.literal("Slider List"))


### PR DESCRIPTION
This PR adds two small patches to `ListOption<T>`.

## Patch 1: Allow to specify size limits for option lists.
This allows to set a "minimum" and a "maximum" length for the option list, beyond which it may not grow/shrink using the GUI. To facilitate that, the "add entry" and "remove entry" buttons are disabled whenever an operation would break these size constraints.

## Patch 2: Allow "reversed" lists that add new options at their end.
ListOptions until now always grew at the top. I had the situation in my mod HaloHUD where I needed a list of entries to grow the opposite way. The workaround is quite ugly: https://github.com/Crendgrim/yaclx/blob/988aa3a7d7efbee935bb412c19681743abfa5a32/common/src/main/java/mod/crend/yaclx/auto/internal/BindingHelper.java#L98

This patch cleans that up by providing an option to the builder to manipulate this behaviour as the mod developer wishes.