### PR TITLE
Add Enum Dropdown Controller

### DIFF
--- a/common/src/main/java/dev/isxander/yacl3/api/NameableEnum.java
+++ b/common/src/main/java/dev/isxander/yacl3/api/NameableEnum.java
@@ -3,7 +3,7 @@ package dev.isxander.yacl3.api;
 import net.minecraft.network.chat.Component;
 
 /**
- * Used for the default value formatter of {@link dev.isxander.yacl3.gui.controllers.cycling.EnumController}
+ * Used for the default value formatter of {@link dev.isxander.yacl3.gui.controllers.cycling.EnumController} and {@link dev.isxander.yacl3.gui.controllers.dropdown.EnumDropdownController}
  */
 public interface NameableEnum {
     Component getDisplayName();

--- a/common/src/main/java/dev/isxander/yacl3/api/controller/EnumDropdownControllerBuilder.java
+++ b/common/src/main/java/dev/isxander/yacl3/api/controller/EnumDropdownControllerBuilder.java
@@ -3,23 +3,8 @@ package dev.isxander.yacl3.api.controller;
 import dev.isxander.yacl3.api.Option;
 import dev.isxander.yacl3.impl.controller.EnumDropdownControllerBuilderImpl;
 
-import java.util.function.Function;
-
 public interface EnumDropdownControllerBuilder<E extends Enum<E>> extends ValueFormattableController<E, EnumDropdownControllerBuilder<E>> {
     static <E extends Enum<E>> EnumDropdownControllerBuilder<E> create(Option<E> option) {
         return new EnumDropdownControllerBuilderImpl<>(option);
-    }
-
-    /**
-     * Creates a factory for {@link EnumDropdownControllerBuilder}s with the given function for converting enum constants to components.
-     * Use this if a custom formatter function for an enum is needed.
-     * Use it like this:
-     * <pre>{@code Option.<MyEnum>createBuilder().controller(EnumDropdownControllerBuilder.getFactory(MY_CUSTOM_ENUM_TO_COMPONENT_FUNCTION))}</pre>
-     * @param formatter The function used to convert enum constants to components used for display, suggestion, and validation
-     * @return a factory for {@link EnumDropdownControllerBuilder}s
-     * @param <E> the enum type
-     */
-    static <E extends Enum<E>> Function<Option<E>, ControllerBuilder<E>> getFactory(ValueFormatter<E> formatter) {
-        return opt -> EnumDropdownControllerBuilder.create(opt).formatValue(formatter);
     }
 }

--- a/common/src/main/java/dev/isxander/yacl3/api/controller/EnumDropdownControllerBuilder.java
+++ b/common/src/main/java/dev/isxander/yacl3/api/controller/EnumDropdownControllerBuilder.java
@@ -3,8 +3,25 @@ package dev.isxander.yacl3.api.controller;
 import dev.isxander.yacl3.api.Option;
 import dev.isxander.yacl3.impl.controller.EnumDropdownControllerBuilderImpl;
 
+import java.util.function.Function;
+
 public interface EnumDropdownControllerBuilder<E extends Enum<E>> extends ControllerBuilder<E> {
+    EnumDropdownControllerBuilder<E> toString(Function<E, String> toString);
+
     static <E extends Enum<E>> EnumDropdownControllerBuilder<E> create(Option<E> option) {
         return new EnumDropdownControllerBuilderImpl<>(option);
+    }
+
+    /**
+     * Creates a factory for {@link EnumDropdownControllerBuilder}s with the given function for converting enum constants to strings.
+     * Use this if a custom toString function for an enum is needed.
+     * Use it like this:
+     * <pre>{@code Option.<MyEnum>createBuilder().controller(createEnumDropdownControllerBuilder.getFactory(MY_CUSTOM_ENUM_TO_STRING_FUNCTION))}</pre>
+     * @param toString The function used to convert enum constants to strings used for display, suggestion, and validation
+     * @return a factory for {@link EnumDropdownControllerBuilder}s
+     * @param <E> the enum type
+     */
+    static <E extends Enum<E>> Function<Option<E>, ControllerBuilder<E>> getFactory(Function<E, String> toString) {
+        return opt -> EnumDropdownControllerBuilder.create(opt).toString(toString);
     }
 }

--- a/common/src/main/java/dev/isxander/yacl3/api/controller/EnumDropdownControllerBuilder.java
+++ b/common/src/main/java/dev/isxander/yacl3/api/controller/EnumDropdownControllerBuilder.java
@@ -5,23 +5,21 @@ import dev.isxander.yacl3.impl.controller.EnumDropdownControllerBuilderImpl;
 
 import java.util.function.Function;
 
-public interface EnumDropdownControllerBuilder<E extends Enum<E>> extends ControllerBuilder<E> {
-    EnumDropdownControllerBuilder<E> toString(Function<E, String> toString);
-
+public interface EnumDropdownControllerBuilder<E extends Enum<E>> extends ValueFormattableController<E, EnumDropdownControllerBuilder<E>> {
     static <E extends Enum<E>> EnumDropdownControllerBuilder<E> create(Option<E> option) {
         return new EnumDropdownControllerBuilderImpl<>(option);
     }
 
     /**
-     * Creates a factory for {@link EnumDropdownControllerBuilder}s with the given function for converting enum constants to strings.
-     * Use this if a custom toString function for an enum is needed.
+     * Creates a factory for {@link EnumDropdownControllerBuilder}s with the given function for converting enum constants to components.
+     * Use this if a custom formatter function for an enum is needed.
      * Use it like this:
-     * <pre>{@code Option.<MyEnum>createBuilder().controller(createEnumDropdownControllerBuilder.getFactory(MY_CUSTOM_ENUM_TO_STRING_FUNCTION))}</pre>
-     * @param toString The function used to convert enum constants to strings used for display, suggestion, and validation
+     * <pre>{@code Option.<MyEnum>createBuilder().controller(EnumDropdownControllerBuilder.getFactory(MY_CUSTOM_ENUM_TO_COMPONENT_FUNCTION))}</pre>
+     * @param formatter The function used to convert enum constants to components used for display, suggestion, and validation
      * @return a factory for {@link EnumDropdownControllerBuilder}s
      * @param <E> the enum type
      */
-    static <E extends Enum<E>> Function<Option<E>, ControllerBuilder<E>> getFactory(Function<E, String> toString) {
-        return opt -> EnumDropdownControllerBuilder.create(opt).toString(toString);
+    static <E extends Enum<E>> Function<Option<E>, ControllerBuilder<E>> getFactory(ValueFormatter<E> formatter) {
+        return opt -> EnumDropdownControllerBuilder.create(opt).formatValue(formatter);
     }
 }

--- a/common/src/main/java/dev/isxander/yacl3/api/controller/EnumDropdownControllerBuilder.java
+++ b/common/src/main/java/dev/isxander/yacl3/api/controller/EnumDropdownControllerBuilder.java
@@ -1,0 +1,10 @@
+package dev.isxander.yacl3.api.controller;
+
+import dev.isxander.yacl3.api.Option;
+import dev.isxander.yacl3.impl.controller.EnumDropdownControllerBuilderImpl;
+
+public interface EnumDropdownControllerBuilder<E extends Enum<E>> extends ControllerBuilder<E> {
+    static <E extends Enum<E>> EnumDropdownControllerBuilder<E> create(Option<E> option) {
+        return new EnumDropdownControllerBuilderImpl<>(option);
+    }
+}

--- a/common/src/main/java/dev/isxander/yacl3/gui/controllers/dropdown/AbstractDropdownController.java
+++ b/common/src/main/java/dev/isxander/yacl3/gui/controllers/dropdown/AbstractDropdownController.java
@@ -26,8 +26,12 @@ public abstract class AbstractDropdownController<T> implements IStringController
 		this.allowAnyValue = allowAnyValue;
 	}
 
+	protected AbstractDropdownController(Option<T> option, List<String> allowedValues) {
+		this(option, allowedValues, false, false);
+	}
+
 	protected AbstractDropdownController(Option<T> option) {
-		this(option, Collections.emptyList(), false, false);
+		this(option, Collections.emptyList());
 	}
 
 	/**

--- a/common/src/main/java/dev/isxander/yacl3/gui/controllers/dropdown/EnumDropdownController.java
+++ b/common/src/main/java/dev/isxander/yacl3/gui/controllers/dropdown/EnumDropdownController.java
@@ -1,29 +1,30 @@
 package dev.isxander.yacl3.gui.controllers.dropdown;
 
 import dev.isxander.yacl3.api.Option;
+import dev.isxander.yacl3.api.controller.ValueFormatter;
 import dev.isxander.yacl3.api.utils.Dimension;
 import dev.isxander.yacl3.gui.AbstractWidget;
 import dev.isxander.yacl3.gui.YACLScreen;
+import net.minecraft.network.chat.Component;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 public class EnumDropdownController<E extends Enum<E>> extends AbstractDropdownController<E> {
     /**
      * The function used to convert enum constants to strings used for display, suggestion, and validation. Defaults to {@link Enum#toString}.
      */
-    protected final Function<E, String> toString;
+    protected final ValueFormatter<E> formatter;
 
-    public EnumDropdownController(Option<E> option, Function<E, String> toString) {
-        super(option, Arrays.stream(option.pendingValue().getDeclaringClass().getEnumConstants()).map(toString).toList());
-        this.toString = toString;
+    public EnumDropdownController(Option<E> option, ValueFormatter<E> formatter) {
+        super(option, Arrays.stream(option.pendingValue().getDeclaringClass().getEnumConstants()).map(formatter::format).map(Component::getString).toList());
+        this.formatter = formatter;
     }
 
     @Override
     public String getString() {
-        return toString.apply(option().pendingValue());
+        return formatter.format(option().pendingValue()).getString();
     }
 
     @Override
@@ -32,15 +33,15 @@ public class EnumDropdownController<E extends Enum<E>> extends AbstractDropdownC
     }
 
     /**
-     * Searches through enum constants for one whose {@link #toString} result equals {@code value}
+     * Searches through enum constants for one whose {@link #formatter} result equals {@code value}
      *
      * @return The enum constant associated with the {@code value} or the pending value if none are found
-     * @implNote The return value of {@link #toString} on each enum constant should be unique in order to ensure accuracy
+     * @implNote The return value of {@link #formatter} on each enum constant should be unique in order to ensure accuracy
      */
     private E getEnumFromString(String value) {
         value = value.toLowerCase();
         for (E constant : option().pendingValue().getDeclaringClass().getEnumConstants()) {
-            if (toString.apply(constant).toLowerCase().equals(value)) return constant;
+            if (formatter.format(constant).getString().toLowerCase().equals(value)) return constant;
         }
 
         return option().pendingValue();
@@ -65,10 +66,10 @@ public class EnumDropdownController<E extends Enum<E>> extends AbstractDropdownC
     }
 
     /**
-     * Filters and sorts through enum constants for those whose {@link #toString} result equals {@code value}
+     * Filters and sorts through enum constants for those whose {@link #formatter} result equals {@code value}
      *
      * @return a sorted stream containing enum constants associated with the {@code value}
-     * @implNote The return value of {@link #toString} on each enum constant should be unique in order to ensure accuracy
+     * @implNote The return value of {@link #formatter} on each enum constant should be unique in order to ensure accuracy
      */
     @NotNull
     protected Stream<String> getValidEnumConstants(String value) {

--- a/common/src/main/java/dev/isxander/yacl3/gui/controllers/dropdown/EnumDropdownController.java
+++ b/common/src/main/java/dev/isxander/yacl3/gui/controllers/dropdown/EnumDropdownController.java
@@ -7,16 +7,23 @@ import dev.isxander.yacl3.gui.YACLScreen;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 public class EnumDropdownController<E extends Enum<E>> extends AbstractDropdownController<E> {
-    public EnumDropdownController(Option<E> option) {
+    /**
+     * The function used to convert enum constants to strings used for display, suggestion, and validation. Defaults to {@link Enum#toString}.
+     */
+    protected final Function<E, String> toString;
+
+    public EnumDropdownController(Option<E> option, Function<E, String> toString) {
         super(option);
+        this.toString = toString;
     }
 
     @Override
     public String getString() {
-        return option().pendingValue().toString();
+        return toString.apply(option().pendingValue());
     }
 
     @Override
@@ -25,15 +32,15 @@ public class EnumDropdownController<E extends Enum<E>> extends AbstractDropdownC
     }
 
     /**
-     * Searches through enum constants for one whose {@link Enum#toString()} result equals {@code value}
+     * Searches through enum constants for one whose {@link #toString} result equals {@code value}
      *
      * @return The enum constant associated with the {@code value} or the pending value if none are found
-     * @implNote The return value of {@link Enum#toString()} on each enum constant should be unique in order to ensure accuracy
+     * @implNote The return value of {@link #toString} on each enum constant should be unique in order to ensure accuracy
      */
     private E getEnumFromString(String value) {
         value = value.toLowerCase();
         for (E constant : option().pendingValue().getDeclaringClass().getEnumConstants()) {
-            if (constant.toString().toLowerCase().equals(value)) return constant;
+            if (toString.apply(constant).toLowerCase().equals(value)) return constant;
         }
 
         return option().pendingValue();
@@ -43,7 +50,7 @@ public class EnumDropdownController<E extends Enum<E>> extends AbstractDropdownC
     public boolean isValueValid(String value) {
         value = value.toLowerCase();
         for (E constant : option().pendingValue().getDeclaringClass().getEnumConstants()) {
-            if (constant.toString().equals(value)) return true;
+            if (toString.apply(constant).equals(value)) return true;
         }
 
         return false;
@@ -58,16 +65,16 @@ public class EnumDropdownController<E extends Enum<E>> extends AbstractDropdownC
     }
 
     /**
-     * Filters and sorts through enum constants for those whose {@link Enum#toString()} result equals {@code value}
+     * Filters and sorts through enum constants for those whose {@link #toString} result equals {@code value}
      *
      * @return a sorted stream containing enum constants associated with the {@code value}
-     * @implNote The return value of {@link Enum#toString()} on each enum constant should be unique in order to ensure accuracy
+     * @implNote The return value of {@link #toString} on each enum constant should be unique in order to ensure accuracy
      */
     @NotNull
     protected Stream<String> getValidEnumConstants(String value) {
         String valueLowerCase = value.toLowerCase();
         return Arrays.stream(option().pendingValue().getDeclaringClass().getEnumConstants())
-                .map(Enum::toString)
+                .map(this.toString)
                 .filter(constant -> constant.toLowerCase().contains(valueLowerCase))
                 .sorted((s1, s2) -> {
                     String s1LowerCase = s1.toLowerCase();

--- a/common/src/main/java/dev/isxander/yacl3/gui/controllers/dropdown/EnumDropdownController.java
+++ b/common/src/main/java/dev/isxander/yacl3/gui/controllers/dropdown/EnumDropdownController.java
@@ -17,7 +17,7 @@ public class EnumDropdownController<E extends Enum<E>> extends AbstractDropdownC
     protected final Function<E, String> toString;
 
     public EnumDropdownController(Option<E> option, Function<E, String> toString) {
-        super(option);
+        super(option, Arrays.stream(option.pendingValue().getDeclaringClass().getEnumConstants()).map(toString).toList());
         this.toString = toString;
     }
 
@@ -49,8 +49,8 @@ public class EnumDropdownController<E extends Enum<E>> extends AbstractDropdownC
     @Override
     public boolean isValueValid(String value) {
         value = value.toLowerCase();
-        for (E constant : option().pendingValue().getDeclaringClass().getEnumConstants()) {
-            if (toString.apply(constant).equals(value)) return true;
+        for (String constant : getAllowedValues()) {
+            if (constant.equals(value)) return true;
         }
 
         return false;
@@ -73,8 +73,7 @@ public class EnumDropdownController<E extends Enum<E>> extends AbstractDropdownC
     @NotNull
     protected Stream<String> getValidEnumConstants(String value) {
         String valueLowerCase = value.toLowerCase();
-        return Arrays.stream(option().pendingValue().getDeclaringClass().getEnumConstants())
-                .map(this.toString)
+        return getAllowedValues().stream()
                 .filter(constant -> constant.toLowerCase().contains(valueLowerCase))
                 .sorted((s1, s2) -> {
                     String s1LowerCase = s1.toLowerCase();

--- a/common/src/main/java/dev/isxander/yacl3/gui/controllers/dropdown/EnumDropdownController.java
+++ b/common/src/main/java/dev/isxander/yacl3/gui/controllers/dropdown/EnumDropdownController.java
@@ -1,0 +1,85 @@
+package dev.isxander.yacl3.gui.controllers.dropdown;
+
+import dev.isxander.yacl3.api.Option;
+import dev.isxander.yacl3.api.utils.Dimension;
+import dev.isxander.yacl3.gui.AbstractWidget;
+import dev.isxander.yacl3.gui.YACLScreen;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+public class EnumDropdownController<E extends Enum<E>> extends AbstractDropdownController<E> {
+    public EnumDropdownController(Option<E> option) {
+        super(option);
+    }
+
+    @Override
+    public String getString() {
+        return option().pendingValue().toString();
+    }
+
+    @Override
+    public void setFromString(String value) {
+        option().requestSet(getEnumFromString(value));
+    }
+
+    /**
+     * Searches through enum constants for one whose {@link Enum#toString()} result equals {@code value}
+     *
+     * @return The enum constant associated with the {@code value} or the pending value if none are found
+     * @implNote The return value of {@link Enum#toString()} on each enum constant should be unique in order to ensure accuracy
+     */
+    private E getEnumFromString(String value) {
+        value = value.toLowerCase();
+        for (E constant : option().pendingValue().getDeclaringClass().getEnumConstants()) {
+            if (constant.toString().toLowerCase().equals(value)) return constant;
+        }
+
+        return option().pendingValue();
+    }
+
+    @Override
+    public boolean isValueValid(String value) {
+        value = value.toLowerCase();
+        for (E constant : option().pendingValue().getDeclaringClass().getEnumConstants()) {
+            if (constant.toString().equals(value)) return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    protected String getValidValue(String value, int offset) {
+        return getValidEnumConstants(value)
+                .skip(offset)
+                .findFirst()
+                .orElseGet(this::getString);
+    }
+
+    /**
+     * Filters and sorts through enum constants for those whose {@link Enum#toString()} result equals {@code value}
+     *
+     * @return a sorted stream containing enum constants associated with the {@code value}
+     * @implNote The return value of {@link Enum#toString()} on each enum constant should be unique in order to ensure accuracy
+     */
+    @NotNull
+    protected Stream<String> getValidEnumConstants(String value) {
+        String valueLowerCase = value.toLowerCase();
+        return Arrays.stream(option().pendingValue().getDeclaringClass().getEnumConstants())
+                .map(Enum::toString)
+                .filter(constant -> constant.toLowerCase().contains(valueLowerCase))
+                .sorted((s1, s2) -> {
+                    String s1LowerCase = s1.toLowerCase();
+                    String s2LowerCase = s2.toLowerCase();
+                    if (s1LowerCase.startsWith(valueLowerCase) && !s2LowerCase.startsWith(valueLowerCase)) return -1;
+                    if (!s1LowerCase.startsWith(valueLowerCase) && s2LowerCase.startsWith(valueLowerCase)) return 1;
+                    return s1.compareTo(s2);
+                });
+    }
+
+    @Override
+    public AbstractWidget provideWidget(YACLScreen screen, Dimension<Integer> widgetDimension) {
+        return new EnumDropdownControllerElement<>(this, screen, widgetDimension);
+    }
+}

--- a/common/src/main/java/dev/isxander/yacl3/gui/controllers/dropdown/EnumDropdownControllerElement.java
+++ b/common/src/main/java/dev/isxander/yacl3/gui/controllers/dropdown/EnumDropdownControllerElement.java
@@ -1,0 +1,25 @@
+package dev.isxander.yacl3.gui.controllers.dropdown;
+
+import dev.isxander.yacl3.api.utils.Dimension;
+import dev.isxander.yacl3.gui.YACLScreen;
+
+import java.util.List;
+
+public class EnumDropdownControllerElement<E extends Enum<E>> extends AbstractDropdownControllerElement<E, String> {
+    private final EnumDropdownController<E> controller;
+
+    public EnumDropdownControllerElement(EnumDropdownController<E> control, YACLScreen screen, Dimension<Integer> dim) {
+        super(control, screen, dim);
+        this.controller = control;
+    }
+
+    @Override
+    public List<String> computeMatchingValues() {
+        return controller.getValidEnumConstants(inputField).toList();
+    }
+
+    @Override
+    public String getString(String object) {
+        return object;
+    }
+}

--- a/common/src/main/java/dev/isxander/yacl3/impl/controller/EnumDropdownControllerBuilderImpl.java
+++ b/common/src/main/java/dev/isxander/yacl3/impl/controller/EnumDropdownControllerBuilderImpl.java
@@ -5,13 +5,23 @@ import dev.isxander.yacl3.api.Option;
 import dev.isxander.yacl3.api.controller.EnumDropdownControllerBuilder;
 import dev.isxander.yacl3.gui.controllers.dropdown.EnumDropdownController;
 
+import java.util.function.Function;
+
 public class EnumDropdownControllerBuilderImpl<E extends Enum<E>> extends AbstractControllerBuilderImpl<E> implements EnumDropdownControllerBuilder<E> {
+    private Function<E, String> toString = Enum::toString;
+
     public EnumDropdownControllerBuilderImpl(Option<E> option) {
         super(option);
     }
 
     @Override
+    public EnumDropdownControllerBuilder<E> toString(Function<E, String> toString) {
+        this.toString = toString;
+        return this;
+    }
+
+    @Override
     public Controller<E> build() {
-        return new EnumDropdownController<>(option);
+        return new EnumDropdownController<>(option, toString);
     }
 }

--- a/common/src/main/java/dev/isxander/yacl3/impl/controller/EnumDropdownControllerBuilderImpl.java
+++ b/common/src/main/java/dev/isxander/yacl3/impl/controller/EnumDropdownControllerBuilderImpl.java
@@ -1,0 +1,17 @@
+package dev.isxander.yacl3.impl.controller;
+
+import dev.isxander.yacl3.api.Controller;
+import dev.isxander.yacl3.api.Option;
+import dev.isxander.yacl3.api.controller.EnumDropdownControllerBuilder;
+import dev.isxander.yacl3.gui.controllers.dropdown.EnumDropdownController;
+
+public class EnumDropdownControllerBuilderImpl<E extends Enum<E>> extends AbstractControllerBuilderImpl<E> implements EnumDropdownControllerBuilder<E> {
+    public EnumDropdownControllerBuilderImpl(Option<E> option) {
+        super(option);
+    }
+
+    @Override
+    public Controller<E> build() {
+        return new EnumDropdownController<>(option);
+    }
+}

--- a/common/src/main/java/dev/isxander/yacl3/impl/controller/EnumDropdownControllerBuilderImpl.java
+++ b/common/src/main/java/dev/isxander/yacl3/impl/controller/EnumDropdownControllerBuilderImpl.java
@@ -3,25 +3,25 @@ package dev.isxander.yacl3.impl.controller;
 import dev.isxander.yacl3.api.Controller;
 import dev.isxander.yacl3.api.Option;
 import dev.isxander.yacl3.api.controller.EnumDropdownControllerBuilder;
+import dev.isxander.yacl3.api.controller.ValueFormatter;
+import dev.isxander.yacl3.gui.controllers.cycling.EnumController;
 import dev.isxander.yacl3.gui.controllers.dropdown.EnumDropdownController;
 
-import java.util.function.Function;
-
 public class EnumDropdownControllerBuilderImpl<E extends Enum<E>> extends AbstractControllerBuilderImpl<E> implements EnumDropdownControllerBuilder<E> {
-    private Function<E, String> toString = Enum::toString;
+    private ValueFormatter<E> formatter = EnumController.<E>getDefaultFormatter()::apply;
 
     public EnumDropdownControllerBuilderImpl(Option<E> option) {
         super(option);
     }
 
     @Override
-    public EnumDropdownControllerBuilder<E> toString(Function<E, String> toString) {
-        this.toString = toString;
+    public EnumDropdownControllerBuilder<E> formatValue(ValueFormatter<E> formatter) {
+        this.formatter = formatter;
         return this;
     }
 
     @Override
     public Controller<E> build() {
-        return new EnumDropdownController<>(option, toString);
+        return new EnumDropdownController<>(option, formatter);
     }
 }

--- a/test-common/src/main/java/dev/isxander/yacl3/test/ConfigTest.java
+++ b/test-common/src/main/java/dev/isxander/yacl3/test/ConfigTest.java
@@ -7,7 +7,6 @@ import dev.isxander.yacl3.platform.YACLPlatform;
 import net.minecraft.ChatFormatting;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
-import org.apache.commons.lang3.StringUtils;
 
 import java.awt.*;
 import java.util.List;
@@ -54,7 +53,7 @@ public class ConfigTest {
     @SerialEntry
     public Item item = Items.OAK_LOG;
     @SerialEntry
-    public FormattingOption formattingOption = FormattingOption.RED;
+    public ChatFormatting formattingOption = ChatFormatting.RED;
 
     @SerialEntry
     public List<String> stringList = List.of("This is quite cool.", "You can add multiple items!", "And it is integrated so well into Option groups!");
@@ -75,42 +74,5 @@ public class ConfigTest {
 
     public enum Alphabet {
         A, B, C
-    }
-
-    public enum FormattingOption {
-        BLACK(ChatFormatting.BLACK),
-        DARK_BLUE(ChatFormatting.DARK_BLUE),
-        DARK_GREEN(ChatFormatting.DARK_GREEN),
-        DARK_AQUA(ChatFormatting.DARK_AQUA),
-        DARK_RED(ChatFormatting.DARK_RED),
-        DARK_PURPLE(ChatFormatting.DARK_PURPLE),
-        GOLD(ChatFormatting.GOLD),
-        GRAY(ChatFormatting.GRAY),
-        DARK_GRAY(ChatFormatting.DARK_GRAY),
-        BLUE(ChatFormatting.BLUE),
-        GREEN(ChatFormatting.GREEN),
-        AQUA(ChatFormatting.AQUA),
-        RED(ChatFormatting.RED),
-        LIGHT_PURPLE(ChatFormatting.LIGHT_PURPLE),
-        YELLOW(ChatFormatting.YELLOW),
-        WHITE(ChatFormatting.WHITE),
-        OBFUSCATED(ChatFormatting.OBFUSCATED),
-        BOLD(ChatFormatting.BOLD),
-        STRIKETHROUGH(ChatFormatting.STRIKETHROUGH),
-        UNDERLINE(ChatFormatting.UNDERLINE),
-        ITALIC(ChatFormatting.ITALIC),
-        RESET(ChatFormatting.RESET);
-
-        public final ChatFormatting formatting;
-
-
-        FormattingOption(ChatFormatting formatting) {
-            this.formatting = formatting;
-        }
-
-        @Override
-        public String toString() {
-            return StringUtils.capitalize(formatting.getName().replaceAll("_", " "));
-        }
     }
 }

--- a/test-common/src/main/java/dev/isxander/yacl3/test/ConfigTest.java
+++ b/test-common/src/main/java/dev/isxander/yacl3/test/ConfigTest.java
@@ -4,8 +4,10 @@ import dev.isxander.yacl3.config.v2.api.ConfigClassHandler;
 import dev.isxander.yacl3.config.v2.api.SerialEntry;
 import dev.isxander.yacl3.config.v2.api.serializer.GsonConfigSerializerBuilder;
 import dev.isxander.yacl3.platform.YACLPlatform;
+import net.minecraft.ChatFormatting;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
+import org.apache.commons.lang3.StringUtils;
 
 import java.awt.*;
 import java.util.List;
@@ -51,6 +53,8 @@ public class ConfigTest {
     public String stringSuggestions = "";
     @SerialEntry
     public Item item = Items.OAK_LOG;
+    @SerialEntry
+    public FormattingOption formattingOption = FormattingOption.RED;
 
     @SerialEntry
     public List<String> stringList = List.of("This is quite cool.", "You can add multiple items!", "And it is integrated so well into Option groups!");
@@ -71,5 +75,42 @@ public class ConfigTest {
 
     public enum Alphabet {
         A, B, C
+    }
+
+    public enum FormattingOption {
+        BLACK(ChatFormatting.BLACK),
+        DARK_BLUE(ChatFormatting.DARK_BLUE),
+        DARK_GREEN(ChatFormatting.DARK_GREEN),
+        DARK_AQUA(ChatFormatting.DARK_AQUA),
+        DARK_RED(ChatFormatting.DARK_RED),
+        DARK_PURPLE(ChatFormatting.DARK_PURPLE),
+        GOLD(ChatFormatting.GOLD),
+        GRAY(ChatFormatting.GRAY),
+        DARK_GRAY(ChatFormatting.DARK_GRAY),
+        BLUE(ChatFormatting.BLUE),
+        GREEN(ChatFormatting.GREEN),
+        AQUA(ChatFormatting.AQUA),
+        RED(ChatFormatting.RED),
+        LIGHT_PURPLE(ChatFormatting.LIGHT_PURPLE),
+        YELLOW(ChatFormatting.YELLOW),
+        WHITE(ChatFormatting.WHITE),
+        OBFUSCATED(ChatFormatting.OBFUSCATED),
+        BOLD(ChatFormatting.BOLD),
+        STRIKETHROUGH(ChatFormatting.STRIKETHROUGH),
+        UNDERLINE(ChatFormatting.UNDERLINE),
+        ITALIC(ChatFormatting.ITALIC),
+        RESET(ChatFormatting.RESET);
+
+        public final ChatFormatting formatting;
+
+
+        FormattingOption(ChatFormatting formatting) {
+            this.formatting = formatting;
+        }
+
+        @Override
+        public String toString() {
+            return StringUtils.capitalize(formatting.getName().replaceAll("_", " "));
+        }
     }
 }

--- a/test-common/src/main/java/dev/isxander/yacl3/test/GuiTest.java
+++ b/test-common/src/main/java/dev/isxander/yacl3/test/GuiTest.java
@@ -277,7 +277,7 @@ public class GuiTest {
                                                         () -> config.formattingOption,
                                                         (value) -> config.formattingOption = value
                                                 )
-                                                .controller(EnumDropdownControllerBuilder.getFactory(formatting -> Component.literal(StringUtils.capitalize(formatting.getName()).replaceAll("_", " "))))
+                                                .controller(option -> EnumDropdownControllerBuilder.create(option).formatValue(formatting -> Component.literal(StringUtils.capitalize(formatting.getName()).replaceAll("_", " "))))
                                                 .build())
                                         .build())
                                 .group(OptionGroup.createBuilder()

--- a/test-common/src/main/java/dev/isxander/yacl3/test/GuiTest.java
+++ b/test-common/src/main/java/dev/isxander/yacl3/test/GuiTest.java
@@ -277,7 +277,7 @@ public class GuiTest {
                                                         () -> config.formattingOption,
                                                         (value) -> config.formattingOption = value
                                                 )
-                                                .controller(EnumDropdownControllerBuilder.getFactory(formatting -> StringUtils.capitalize(formatting.getName()).replaceAll("_", " ")))
+                                                .controller(EnumDropdownControllerBuilder.getFactory(formatting -> Component.literal(StringUtils.capitalize(formatting.getName()).replaceAll("_", " "))))
                                                 .build())
                                         .build())
                                 .group(OptionGroup.createBuilder()

--- a/test-common/src/main/java/dev/isxander/yacl3/test/GuiTest.java
+++ b/test-common/src/main/java/dev/isxander/yacl3/test/GuiTest.java
@@ -275,6 +275,15 @@ public class GuiTest {
                                                 )
                                                 .controller(ItemControllerBuilder::create)
                                                 .build())
+                                        .option(Option.<ConfigTest.FormattingOption>createBuilder()
+                                                .name(Component.literal("Enum Dropdown"))
+                                                .binding(
+                                                        defaults.formattingOption,
+                                                        () -> config.formattingOption,
+                                                        (value) -> config.formattingOption = value
+                                                )
+                                                .controller(EnumDropdownControllerBuilder::create)
+                                                .build())
                                         .build())
                                 .group(OptionGroup.createBuilder()
                                         .name(Component.literal("Options that aren't really options"))

--- a/test-common/src/main/java/dev/isxander/yacl3/test/GuiTest.java
+++ b/test-common/src/main/java/dev/isxander/yacl3/test/GuiTest.java
@@ -14,6 +14,7 @@ import dev.isxander.yacl3.gui.controllers.string.number.DoubleFieldController;
 import dev.isxander.yacl3.gui.controllers.string.number.FloatFieldController;
 import dev.isxander.yacl3.gui.controllers.string.number.IntegerFieldController;
 import dev.isxander.yacl3.gui.controllers.string.number.LongFieldController;
+import net.minecraft.ChatFormatting;
 import net.minecraft.Util;
 import net.minecraft.client.GraphicsStatus;
 import net.minecraft.client.Minecraft;
@@ -24,6 +25,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
+import org.apache.commons.lang3.StringUtils;
 
 import java.awt.Color;
 import java.nio.file.Path;
@@ -275,14 +277,14 @@ public class GuiTest {
                                                 )
                                                 .controller(ItemControllerBuilder::create)
                                                 .build())
-                                        .option(Option.<ConfigTest.FormattingOption>createBuilder()
+                                        .option(Option.<ChatFormatting>createBuilder()
                                                 .name(Component.literal("Enum Dropdown"))
                                                 .binding(
                                                         defaults.formattingOption,
                                                         () -> config.formattingOption,
                                                         (value) -> config.formattingOption = value
                                                 )
-                                                .controller(EnumDropdownControllerBuilder::create)
+                                                .controller(EnumDropdownControllerBuilder.getFactory(formatting -> StringUtils.capitalize(formatting.getName()).replaceAll("_", " ")))
                                                 .build())
                                         .build())
                                 .group(OptionGroup.createBuilder()


### PR DESCRIPTION
Adds a Dropdown Controller for Enums and a test option.  

The code is modeled after the existing dropdown controllers added in #95 and supports any enum option.  
For default, `Enum#toString` is used to get the display name of the enum constant, which is the name of the enum constant by default. However, users are encouraged to override the toString method in their enum or supply a custom toString function with `EnumDropdownControllerBuilder#getFactory`.  

This PR is being upstreamed from [Skyblocker](<https://github.com/SkyblockerMod/Skyblocker>). See how we're using this controller [here](<https://github.com/SkyblockerMod/Skyblocker/blob/master/src/main/java/de/hysky/skyblocker/config/categories/DungeonsCategory.java#L190>).