### PR TITLE
Backport a very important Forge fix to 1.20.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,12 +93,12 @@ githubRelease {
 
     val githubProject: String by rootProject
     val split = githubProject.split("/")
-    owner(split[0])
-    repo(split[1])
-    tagName("${project.version}")
-    targetCommitish(grgit.branch.current().name)
-    body(changelogText)
-    prerelease(isBeta)
+    owner.set(split[0])
+    repo.set(split[1])
+    tagName.set("${project.version}")
+    targetCommitish.set(grgit.branch.current().name)
+    body.set(changelogText)
+    prerelease.set(isBeta)
     releaseAssets(
         { findProject(":fabric")?.tasks?.get("remapJar")?.outputs?.files },
         { findProject(":fabric")?.tasks?.get("remapSourcesJar")?.outputs?.files },

--- a/common/src/main/resources/yacl.mixins.json
+++ b/common/src/main/resources/yacl.mixins.json
@@ -7,7 +7,6 @@
   },
   "client": [
     "AbstractSelectionListMixin",
-    "ContainerEventHandlerMixin",
     "MinecraftMixin",
     "OptionInstanceAccessor"
   ]

--- a/fabric/src/main/java/dev/isxander/yacl3/fabric/mixin/ContainerEventHandlerMixin.java
+++ b/fabric/src/main/java/dev/isxander/yacl3/fabric/mixin/ContainerEventHandlerMixin.java
@@ -1,4 +1,4 @@
-package dev.isxander.yacl3.mixin;
+package dev.isxander.yacl3.fabric.mixin;
 
 import net.minecraft.client.gui.components.events.ContainerEventHandler;
 import net.minecraft.client.gui.components.events.GuiEventListener;
@@ -14,6 +14,10 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 
 import java.util.List;
 
+/**
+ * This is in Fabric-only because only the Fabric fork of mixin supports @Redirect on interfaces.
+ * This will change in the next release of Mixin.
+ */
 @Mixin(ContainerEventHandler.class)
 public interface ContainerEventHandlerMixin {
     /**

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -22,7 +22,8 @@
     "fabric-resource-loader-v0": "*"
   },
   "mixins": [
-    "yacl.mixins.json"
+    "yacl.mixins.json",
+    "yacl-fabric.mixins.json"
   ],
   "custom": {
     "modmenu": {

--- a/fabric/src/main/resources/yacl-fabric.mixins.json
+++ b/fabric/src/main/resources/yacl-fabric.mixins.json
@@ -1,0 +1,11 @@
+{
+  "required": true,
+  "package": "dev.isxander.yacl3.fabric.mixin",
+  "compatibilityLevel": "JAVA_17",
+  "injectors": {
+    "defaultRequire": 1
+  },
+  "client": [
+    "ContainerEventHandlerMixin"
+  ]
+}


### PR DESCRIPTION
This PR moves `ContainerEventHandlerMixin` to the fabric subproject, as in newer versions of YACL. This will allow the mod to actually be used on forge 1.20.1.