### PR TITLE
Add `Map` support

### DIFF
--- a/common/src/main/java/dev/isxander/yacl3/api/MapOption.java
+++ b/common/src/main/java/dev/isxander/yacl3/api/MapOption.java
@@ -1,0 +1,164 @@
+package dev.isxander.yacl3.api;
+
+import com.google.common.collect.ImmutableList;
+import dev.isxander.yacl3.api.controller.ControllerBuilder;
+import dev.isxander.yacl3.impl.MapOptionImpl;
+import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public interface MapOption<S, T> extends OptionGroup, Option<Map<S, T>> {
+	@Override
+	@NotNull ImmutableList<MapOptionEntry<S, T>> options();
+
+	@ApiStatus.Internal
+	int numberOfEntries();
+
+	@ApiStatus.Internal
+	int maximumNumberOfEntries();
+
+	@ApiStatus.Internal
+	int minimumNumberOfEntries();
+
+	@ApiStatus.Internal
+	MapOptionEntry<S, T> insertNewEntry();
+
+	@ApiStatus.Internal
+	void insertEntry(int index, MapOptionEntry<?, ?> entry);
+
+	@ApiStatus.Internal
+	int indexOf(MapOptionEntry<?, ?> entry);
+
+	@ApiStatus.Internal
+	void removeEntry(MapOptionEntry<?, ?> entry);
+
+	@ApiStatus.Internal
+	void addRefreshListener(Runnable changedListener);
+
+	static <S, T> Builder<S, T> createBuilder() {
+		return new MapOptionImpl.BuilderImpl<>();
+	}
+
+	interface Builder<S, T> {
+		/**
+		 * Sets name of the list, for UX purposes, a name should always be given,
+		 * but isn't enforced.
+		 *
+		 * @see ListOption#name()
+		 */
+		Builder<S, T> name(@NotNull Component name);
+
+		Builder<S, T> description(@NotNull OptionDescription description);
+
+		/**
+		 * Sets the value that is used when creating new entries
+		 */
+		Builder<S, T> initial(@NotNull Supplier<Map.Entry<S, T>> initialValue);
+
+		/**
+		 * Sets the value that is used when creating new entries
+		 */
+		Builder<S, T> initial(@NotNull Map.Entry<S, T> initialValue);
+
+		Builder<S, T> keyController(@NotNull Function<MapOptionEntry<S, T>, ControllerBuilder<S>> controller);
+
+		Builder<S, T> valueController(@NotNull Function<MapOptionEntry<S, T>, ControllerBuilder<T>> controller);
+
+		/**
+		 * Sets the controller for the option.
+		 * This is how you interact and change the options.
+		 *
+		 * @see dev.isxander.yacl3.gui.controllers
+		 */
+		Builder<S, T> customController(@NotNull Function<MapOptionEntry<S, T>, Controller<S>> keyControl, @NotNull Function<MapOptionEntry<S, T>, Controller<T>> valueControl);
+
+		/**
+		 * Sets the binding for the option.
+		 * Used for default, getter and setter.
+		 *
+		 * @see Binding
+		 */
+		Builder<S, T> binding(@NotNull Binding<Map<S, T>> binding);
+
+		/**
+		 * Sets the binding for the option.
+		 * Shorthand of {@link Binding#generic(Object, Supplier, Consumer)}
+		 *
+		 * @param def    default value of the option, used to reset
+		 * @param getter should return the current value of the option
+		 * @param setter should set the option to the supplied value
+		 * @see Binding
+		 */
+		Builder<S, T> binding(@NotNull Map<S, T> def, @NotNull Supplier<@NotNull Map<S, T>> getter, @NotNull Consumer<@NotNull Map<S, T>> setter);
+
+		/**
+		 * Sets if the option can be configured
+		 *
+		 * @see Option#available()
+		 */
+		Builder<S, T> available(boolean available);
+
+		/**
+		 * Sets a minimum size for the list. Once this size is reached,
+		 * no further entries may be removed.
+		 */
+		Builder<S, T> minimumNumberOfEntries(int number);
+
+		/**
+		 * Sets a maximum size for the list. Once this size is reached,
+		 * no further entries may be added.
+		 */
+		Builder<S, T> maximumNumberOfEntries(int number);
+
+		/**
+		 * Dictates if new entries should be added to the end of the list
+		 * rather than the top.
+		 */
+		Builder<S, T> insertEntriesAtEnd(boolean insertAtEnd);
+
+		/**
+		 * Adds a flag to the option.
+		 * Upon applying changes, all flags are executed.
+		 * {@link Option#flags()}
+		 */
+		Builder<S, T> flag(@NotNull OptionFlag... flag);
+
+		/**
+		 * Adds a flag to the option.
+		 * Upon applying changes, all flags are executed.
+		 * {@link Option#flags()}
+		 */
+		Builder<S, T> flags(@NotNull Collection<OptionFlag> flags);
+
+		/**
+		 * Dictates if the group should be collapsed by default.
+		 * If not set, it will not be collapsed by default.
+		 *
+		 * @see OptionGroup#collapsed()
+		 */
+		Builder<S, T> collapsed(boolean collapsible);
+
+		/**
+		 * Adds a listener to the option. Invoked upon changing any of the list's entries.
+		 *
+		 * @see Option#addListener(BiConsumer)
+		 */
+		Builder<S, T> listener(@NotNull BiConsumer<Option<Map<S, T>>, Map<S, T>> listener);
+
+		/**
+		 * Adds multiple listeners to the option. Invoked upon changing of any of the list's entries.
+		 *
+		 * @see Option#addListener(BiConsumer)
+		 */
+		Builder<S, T> listeners(@NotNull Collection<BiConsumer<Option<Map<S, T>>, Map<S, T>>> listeners);
+
+		MapOption<S, T> build();
+	}
+}

--- a/common/src/main/java/dev/isxander/yacl3/api/MapOptionEntry.java
+++ b/common/src/main/java/dev/isxander/yacl3/api/MapOptionEntry.java
@@ -1,0 +1,18 @@
+package dev.isxander.yacl3.api;
+
+import com.google.common.collect.ImmutableSet;
+import org.jetbrains.annotations.NotNull;
+
+public interface MapOptionEntry<S, T> extends Option<T> {
+	MapOption<S, T> parentGroup();
+
+	@Override
+	default @NotNull ImmutableSet<OptionFlag> flags() {
+		return parentGroup().flags();
+	}
+
+	@Override
+	default boolean available() {
+		return parentGroup().available();
+	}
+}

--- a/common/src/main/java/dev/isxander/yacl3/gui/controllers/LabelController.java
+++ b/common/src/main/java/dev/isxander/yacl3/gui/controllers/LabelController.java
@@ -1,6 +1,7 @@
 package dev.isxander.yacl3.gui.controllers;
 
 import dev.isxander.yacl3.api.Controller;
+import dev.isxander.yacl3.api.MapOptionEntry;
 import dev.isxander.yacl3.api.Option;
 import dev.isxander.yacl3.api.utils.Dimension;
 import dev.isxander.yacl3.gui.AbstractWidget;
@@ -20,6 +21,7 @@ import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Simply renders some text as a label.
@@ -45,6 +47,11 @@ public class LabelController implements Controller<Component> {
 
     @Override
     public Component formatValue() {
+        // TODO: How should this be handled?
+        if (option() instanceof MapOptionEntry<?, ?> mapOptionEntry) {
+            return (Component) ((Map.Entry<?, ?>) mapOptionEntry.pendingValue()).getKey();
+        }
+
         return option().pendingValue();
     }
 

--- a/common/src/main/java/dev/isxander/yacl3/gui/controllers/MapEntryWidget.java
+++ b/common/src/main/java/dev/isxander/yacl3/gui/controllers/MapEntryWidget.java
@@ -1,0 +1,136 @@
+package dev.isxander.yacl3.gui.controllers;
+
+import com.google.common.collect.ImmutableList;
+import dev.isxander.yacl3.api.MapOption;
+import dev.isxander.yacl3.api.MapOptionEntry;
+import dev.isxander.yacl3.api.utils.Dimension;
+import dev.isxander.yacl3.gui.AbstractWidget;
+import dev.isxander.yacl3.gui.TooltipButtonWidget;
+import dev.isxander.yacl3.gui.YACLScreen;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.events.ContainerEventHandler;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
+import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class MapEntryWidget extends AbstractWidget implements ContainerEventHandler {
+	private final TooltipButtonWidget removeButton, moveUpButton, moveDownButton;
+	private final AbstractWidget entryWidget;
+
+	private final MapOption<?, ?> mapOption;
+	private final MapOptionEntry<?, ?> mapOptionEntry;
+
+	private final String optionNameString;
+
+	private GuiEventListener focused;
+	private boolean dragging;
+
+	@SuppressWarnings("UnnecessaryUnicodeEscape")
+	public MapEntryWidget(YACLScreen screen, @NotNull MapOptionEntry<?, ?> mapOptionEntry, @NotNull AbstractWidget entryWidget) {
+		super(entryWidget.getDimension().withHeight(
+				Math.max(entryWidget.getDimension().height(), 20) - ((mapOptionEntry.parentGroup().indexOf(
+						mapOptionEntry) == mapOptionEntry.parentGroup().options().size() - 1) ? 0 : 2))); // -2 to remove the padding
+		this.mapOptionEntry = mapOptionEntry;
+		this.mapOption = mapOptionEntry.parentGroup();
+		this.optionNameString = mapOptionEntry.name().getString().toLowerCase();
+		this.entryWidget = entryWidget;
+
+		Dimension<Integer> dim = entryWidget.getDimension();
+		entryWidget.setDimension(dim.clone().move(20 * 2, 0).expand(-20 * 3, 0));
+
+		removeButton = new TooltipButtonWidget(screen, dim.xLimit() - 20, dim.y(), 20, 20, Component.literal("\u274c"),
+				Component.translatable("yacl.list.remove"), btn -> {
+			mapOption.removeEntry(mapOptionEntry);
+			updateButtonStates();
+		}
+		);
+
+		moveUpButton = new TooltipButtonWidget(
+				screen, dim.x(), dim.y(), 20, 20, Component.literal("\u2191"), Component.translatable("yacl.list.move_up"), btn -> {
+			int index = mapOption.indexOf(mapOptionEntry) - 1;
+			if (index >= 0) {
+				mapOption.removeEntry(mapOptionEntry);
+				mapOption.insertEntry(index, mapOptionEntry);
+				updateButtonStates();
+			}
+		});
+
+		moveDownButton = new TooltipButtonWidget(
+				screen, dim.x() + 20, dim.y(), 20, 20, Component.literal("\u2193"), Component.translatable("yacl.list.move_down"), btn -> {
+			int index = mapOption.indexOf(mapOptionEntry) + 1;
+			if (index < mapOption.options().size()) {
+				mapOption.removeEntry(mapOptionEntry);
+				mapOption.insertEntry(index, mapOptionEntry);
+				updateButtonStates();
+			}
+		});
+
+		updateButtonStates();
+	}
+
+	@Override
+	public void render(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+		updateButtonStates(); // update every render in case option becomes available/unavailable
+
+		removeButton.setY(getDimension().y());
+		moveUpButton.setY(getDimension().y());
+		moveDownButton.setY(getDimension().y());
+		entryWidget.setDimension(entryWidget.getDimension().withY(getDimension().y()));
+
+		removeButton.render(graphics, mouseX, mouseY, delta);
+		moveUpButton.render(graphics, mouseX, mouseY, delta);
+		moveDownButton.render(graphics, mouseX, mouseY, delta);
+		entryWidget.render(graphics, mouseX, mouseY, delta);
+	}
+
+	protected void updateButtonStates() {
+		removeButton.active = mapOption.available() && mapOption.numberOfEntries() > mapOption.minimumNumberOfEntries();
+		moveUpButton.active = mapOption.indexOf(mapOptionEntry) > 0 && mapOption.available();
+		moveDownButton.active = mapOption.indexOf(mapOptionEntry) < mapOption.options().size() - 1 && mapOption.available();
+	}
+
+	@Override
+	public void unfocus() {
+		entryWidget.unfocus();
+	}
+
+	@Override
+	public void updateNarration(NarrationElementOutput builder) {
+		entryWidget.updateNarration(builder);
+	}
+
+	@Override
+	public boolean matchesSearch(String query) {
+		return optionNameString.contains(query.toLowerCase());
+	}
+
+	@Override
+	public @NotNull List<? extends GuiEventListener> children() {
+		return ImmutableList.of(moveUpButton, moveDownButton, entryWidget, removeButton);
+	}
+
+	@Override
+	public boolean isDragging() {
+		return dragging;
+	}
+
+	@Override
+	public void setDragging(boolean dragging) {
+		this.dragging = dragging;
+	}
+
+	@Nullable
+	@Override
+	public GuiEventListener getFocused() {
+		return focused;
+	}
+
+	@Override
+	public void setFocused(@Nullable GuiEventListener focused) {
+		this.focused = focused;
+	}
+}

--- a/common/src/main/java/dev/isxander/yacl3/gui/controllers/string/StringController.java
+++ b/common/src/main/java/dev/isxander/yacl3/gui/controllers/string/StringController.java
@@ -1,6 +1,9 @@
 package dev.isxander.yacl3.gui.controllers.string;
 
+import dev.isxander.yacl3.api.MapOptionEntry;
 import dev.isxander.yacl3.api.Option;
+
+import java.util.Map;
 
 /**
  * A custom text field implementation for strings.
@@ -27,6 +30,11 @@ public class StringController implements IStringController<String> {
 
     @Override
     public String getString() {
+        // TODO: How should this be handled?
+        if (option() instanceof MapOptionEntry<?, ?> mapOptionEntry) {
+            return ((Map.Entry<?, ?>) mapOptionEntry.pendingValue()).getKey().toString();
+        }
+
         return option().pendingValue();
     }
 

--- a/common/src/main/java/dev/isxander/yacl3/impl/HiddenNameMapOptionEntry.java
+++ b/common/src/main/java/dev/isxander/yacl3/impl/HiddenNameMapOptionEntry.java
@@ -1,0 +1,107 @@
+package dev.isxander.yacl3.impl;
+
+import com.google.common.collect.ImmutableSet;
+import dev.isxander.yacl3.api.*;
+import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.BiConsumer;
+
+public class HiddenNameMapOptionEntry<S, T> implements MapOptionEntry<S, T> {
+	private final MapOptionEntry<S, T> option;
+
+	public HiddenNameMapOptionEntry(MapOptionEntry<S, T> option) {
+		this.option = option;
+	}
+
+	@Override
+	public @NotNull Component name() {
+		return Component.empty();
+	}
+
+	@Override
+	public @NotNull OptionDescription description() {
+		return option.description();
+	}
+
+	@Override
+	@Deprecated
+	public @NotNull Component tooltip() {
+		return option.tooltip();
+	}
+
+	@Override
+	public @NotNull Controller<T> controller() {
+		return option.controller();
+	}
+
+	@Override
+	public @NotNull Binding<T> binding() {
+		return option.binding();
+	}
+
+	@Override
+	public boolean available() {
+		return option.available();
+	}
+
+	@Override
+	public void setAvailable(boolean available) {
+		option.setAvailable(available);
+	}
+
+	@Override
+	public MapOption<S, T> parentGroup() {
+		return option.parentGroup();
+	}
+
+	@Override
+	public @NotNull ImmutableSet<OptionFlag> flags() {
+		return option.flags();
+	}
+
+	@Override
+	public boolean changed() {
+		return option.changed();
+	}
+
+	@Override
+	public @NotNull T pendingValue() {
+		return option.pendingValue();
+	}
+
+	@Override
+	public void requestSet(@NotNull T value) {
+		option.requestSet(value);
+	}
+
+	@Override
+	public boolean applyValue() {
+		return option.applyValue();
+	}
+
+	@Override
+	public void forgetPendingValue() {
+		option.forgetPendingValue();
+	}
+
+	@Override
+	public void requestSetDefault() {
+		option.requestSetDefault();
+	}
+
+	@Override
+	public boolean isPendingValueDefault() {
+		return option.isPendingValueDefault();
+	}
+
+	@Override
+	public boolean canResetToDefault() {
+		return option.canResetToDefault();
+	}
+
+	@Override
+	public void addListener(BiConsumer<Option<T>, T> changedListener) {
+		option.addListener(changedListener);
+	}
+}

--- a/common/src/main/java/dev/isxander/yacl3/impl/MapOptionEntryImpl.java
+++ b/common/src/main/java/dev/isxander/yacl3/impl/MapOptionEntryImpl.java
@@ -1,0 +1,141 @@
+package dev.isxander.yacl3.impl;
+
+import dev.isxander.yacl3.api.*;
+import dev.isxander.yacl3.api.utils.Dimension;
+import dev.isxander.yacl3.gui.AbstractWidget;
+import dev.isxander.yacl3.gui.YACLScreen;
+import dev.isxander.yacl3.gui.controllers.MapEntryWidget;
+import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+public class MapOptionEntryImpl<S, T> implements MapOptionEntry<S, T> {
+	private final MapOptionImpl<S, T> group;
+
+	private Map.Entry<S, T> value;
+
+	private final Binding<T> binding;
+	private final Controller<T> controller;
+
+	MapOptionEntryImpl(MapOptionImpl<S, T> group, Map.Entry<S, T> initialValue, @NotNull Function<MapOptionEntry<S, T>, Controller<S>> keyControlGetter, @NotNull Function<MapOptionEntry<S, T>, Controller<T>> valueControlGetter) {
+		this.group = group;
+		this.value = initialValue;
+		this.binding = new EntryBinding();
+		this.controller = new EntryController<>(
+				keyControlGetter.apply(new HiddenNameMapOptionEntry<>(this)),
+				valueControlGetter.apply(new HiddenNameMapOptionEntry<>(this)), this
+		);
+	}
+
+	@Override
+	public MapOption<S, T> parentGroup() {
+		return group;
+	}
+
+	@Override
+	public @NotNull Component name() {
+		return group.name();
+	}
+
+	@Override
+	public @NotNull OptionDescription description() {
+		return group.description();
+	}
+
+	@Override
+	public @NotNull Component tooltip() {
+		return group.tooltip();
+	}
+
+	@Override
+	public @NotNull Controller<T> controller() {
+		return controller;
+	}
+
+	@Override
+	public @NotNull Binding<T> binding() {
+		return binding;
+	}
+
+	@Override
+	public void setAvailable(boolean available) {}
+
+	@Override
+	public boolean changed() {
+		return false;
+	}
+
+	@Override
+	public @NotNull T pendingValue() {
+		return (T) value;
+	}
+
+	@Override
+	public void requestSet(@NotNull T value) {
+		binding.setValue(value);
+	}
+
+	@Override
+	public boolean applyValue() {
+		return false;
+	}
+
+	@Override
+	public void forgetPendingValue() {}
+
+	@Override
+	public void requestSetDefault() {}
+
+	@Override
+	public boolean isPendingValueDefault() {
+		return false;
+	}
+
+	@Override
+	public void addListener(BiConsumer<Option<T>, T> changedListener) {}
+
+	/**
+	 * Open in case mods need to find the real controller type.
+	 */
+	@ApiStatus.Internal
+	public record EntryController<S, T>(Controller<S> keyController, Controller<T> valueController,
+	                                    MapOptionEntryImpl<S, T> entry) implements Controller<T> {
+		@Override
+		public Option<T> option() {
+			return valueController.option();
+		}
+
+		@Override
+		public Component formatValue() {
+			return keyController.formatValue();
+		}
+
+		@Override
+		public AbstractWidget provideWidget(YACLScreen screen, Dimension<Integer> widgetDimension) {
+			// TODO: Update widget to include map values alongside keys
+			return new MapEntryWidget(screen, entry, keyController.provideWidget(screen, widgetDimension));
+		}
+	}
+
+	private class EntryBinding implements Binding<T> {
+		@Override
+		public void setValue(T newValue) {
+			value = (Map.Entry<S, T>) newValue;
+			group.callListeners(true);
+		}
+
+		@Override
+		public T getValue() {
+			return (T) value;
+		}
+
+		@Override
+		public T defaultValue() {
+			throw new UnsupportedOperationException();
+		}
+	}
+}

--- a/common/src/main/java/dev/isxander/yacl3/impl/MapOptionImpl.java
+++ b/common/src/main/java/dev/isxander/yacl3/impl/MapOptionImpl.java
@@ -1,0 +1,429 @@
+package dev.isxander.yacl3.impl;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import dev.isxander.yacl3.api.*;
+import dev.isxander.yacl3.api.controller.ControllerBuilder;
+import dev.isxander.yacl3.impl.utils.YACLConstants;
+import net.minecraft.network.chat.Component;
+import org.apache.commons.lang3.Validate;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public final class MapOptionImpl<S, T> implements MapOption<S, T> {
+	private final Component name;
+	private final OptionDescription description;
+	private final Binding<Map<S, T>> binding;
+	private final Supplier<Map.Entry<S, T>> initialValue;
+	private final List<MapOptionEntry<S, T>> entries;
+	private final boolean collapsed;
+	private boolean available;
+	private final int minimumNumberOfEntries;
+	private final int maximumNumberOfEntries;
+	private final boolean insertEntriesAtEnd;
+	private final ImmutableSet<OptionFlag> flags;
+	private final EntryFactory entryFactory;
+
+	private final List<BiConsumer<Option<Map<S, T>>, Map<S, T>>> listeners;
+	private final List<Runnable> refreshListeners;
+	private int listenerTriggerDepth = 0;
+
+	@Override
+	public @NotNull Controller<Map<S, T>> controller() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public @NotNull Binding<Map<S, T>> binding() {
+		return binding;
+	}
+
+	public MapOptionImpl(@NotNull Component name, @NotNull OptionDescription description, @NotNull Binding<Map<S, T>> binding, @NotNull Supplier<Map.Entry<S, T>> initialValue, @NotNull Function<MapOptionEntry<S, T>, Controller<S>> keyControllerFunction, @NotNull Function<MapOptionEntry<S, T>, Controller<T>> valueControllerFunction, ImmutableSet<OptionFlag> flags, boolean collapsed, boolean available, int minimumNumberOfEntries, int maximumNumberOfEntries, boolean insertEntriesAtEnd, Collection<BiConsumer<Option<Map<S, T>>, Map<S, T>>> listeners) {
+		this.name = name;
+		this.description = description;
+		this.binding = new SafeBinding<>(binding);
+		this.initialValue = initialValue;
+		this.entryFactory = new EntryFactory(keyControllerFunction, valueControllerFunction);
+		this.entries = createEntries(binding().getValue());
+		this.collapsed = collapsed;
+		this.flags = flags;
+		this.available = available;
+		this.minimumNumberOfEntries = minimumNumberOfEntries;
+		this.maximumNumberOfEntries = maximumNumberOfEntries;
+		this.insertEntriesAtEnd = insertEntriesAtEnd;
+		this.listeners = new ArrayList<>();
+		this.listeners.addAll(listeners);
+		this.refreshListeners = new ArrayList<>();
+		callListeners(true);
+	}
+
+	@Override
+	public @NotNull ImmutableList<MapOptionEntry<S, T>> options() {
+		return ImmutableList.copyOf(entries);
+	}
+
+	@Override
+	public int numberOfEntries() {
+		return entries.size();
+	}
+
+	@Override
+	public int maximumNumberOfEntries() {
+		return maximumNumberOfEntries;
+	}
+
+	@Override
+	public int minimumNumberOfEntries() {
+		return minimumNumberOfEntries;
+	}
+
+	@Override
+	public MapOptionEntry<S, T> insertNewEntry() {
+		MapOptionEntry<S, T> newEntry = entryFactory.create(initialValue.get());
+		if (insertEntriesAtEnd) {
+			entries.add(newEntry);
+		} else {
+			// insert at top
+			entries.add(0, newEntry);
+		}
+		onRefresh();
+		return newEntry;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void insertEntry(int index, MapOptionEntry<?, ?> entry) {
+		entries.add(index, (MapOptionEntry<S, T>) entry);
+		onRefresh();
+	}
+
+	@Override
+	public int indexOf(MapOptionEntry<?, ?> entry) {
+		return entries.indexOf(entry);
+	}
+
+	@Override
+	public void removeEntry(MapOptionEntry<?, ?> entry) {
+		if (entries.remove(entry)) {
+			onRefresh();
+		}
+	}
+
+	@Override
+	public void addRefreshListener(Runnable changedListener) {
+		this.refreshListeners.add(changedListener);
+	}
+
+	@Override
+	public boolean available() {
+		return available;
+	}
+
+	@Override
+	public void setAvailable(boolean available) {
+		boolean changed = this.available != available;
+		this.available = available;
+
+		if (changed) {
+			callListeners(false);
+		}
+	}
+
+	@Override
+	public @NotNull ImmutableSet<OptionFlag> flags() {
+		return flags;
+	}
+
+	@Override
+	public boolean changed() {
+		return !binding().getValue().equals(pendingValue());
+	}
+
+	@Override
+	public @NotNull Map<S, T> pendingValue() {
+		// TODO: Refactor into a method
+		Map<S, T> mapEntries = new HashMap<>();
+
+		for (MapOptionEntry<S, T> entry : entries) {
+			var mapEntry = (Map.Entry<S, T>) entry.pendingValue();
+			mapEntries.put(mapEntry.getKey(), mapEntry.getValue());
+		}
+
+		return mapEntries;
+	}
+
+	@Override
+	public boolean applyValue() {
+		if (changed()) {
+			binding().setValue(pendingValue());
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public void forgetPendingValue() {
+		requestSet(binding().getValue());
+	}
+
+	@Override
+	public void requestSetDefault() {
+		requestSet(binding().defaultValue());
+	}
+
+	@Override
+	public boolean isPendingValueDefault() {
+		return binding().defaultValue().equals(pendingValue());
+	}
+
+	@Override
+	public void addListener(BiConsumer<Option<Map<S, T>>, Map<S, T>> changedListener) {
+		this.listeners.add(changedListener);
+	}
+
+	@Override
+	public void requestSet(@NotNull Map<S, T> value) {
+		entries.clear();
+		entries.addAll(createEntries(value));
+		onRefresh();
+	}
+
+	@Override
+	public @NotNull Component name() {
+		return name;
+	}
+
+	@Override
+	public @NotNull OptionDescription description() {
+		return description;
+	}
+
+	@Override
+	public @NotNull Component tooltip() {
+		return description().text();
+	}
+
+	@Override
+	public boolean collapsed() {
+		return collapsed;
+	}
+
+	@Override
+	public boolean isRoot() {
+		return false;
+	}
+
+	private List<MapOptionEntry<S, T>> createEntries(Map<S, T> values) {
+		return values.entrySet().stream().filter(Objects::nonNull).map(entryFactory::create).collect(Collectors.toList());
+	}
+
+	void callListeners(boolean bypass) {
+		Map<S, T> pendingValue = pendingValue();
+		if (bypass || listenerTriggerDepth == 0) {
+			if (listenerTriggerDepth > 10) {
+				throw new IllegalStateException(
+						"Listener trigger depth exceeded 10! This means a listener triggered a listener etc etc 10 times deep. This is likely a bug in the mod using YACL!");
+			}
+
+			this.listenerTriggerDepth++;
+
+			for (BiConsumer<Option<Map<S, T>>, Map<S, T>> listener : listeners) {
+				try {
+					listener.accept(this, pendingValue);
+				} catch (Exception e) {
+					YACLConstants.LOGGER.error("Exception whilst triggering listener for option '%s'".formatted(name.getString()), e);
+				}
+			}
+
+			this.listenerTriggerDepth--;
+		}
+	}
+
+	private void onRefresh() {
+		refreshListeners.forEach(Runnable::run);
+		callListeners(true);
+	}
+
+	private class EntryFactory {
+		private final Function<MapOptionEntry<S, T>, Controller<S>> keyControllerFunction;
+		private final Function<MapOptionEntry<S, T>, Controller<T>> valueControllerFunction;
+
+		private EntryFactory(Function<MapOptionEntry<S, T>, Controller<S>> keyControllerFunction, Function<MapOptionEntry<S, T>, Controller<T>> valueControllerFunction) {
+			this.keyControllerFunction = keyControllerFunction;
+			this.valueControllerFunction = valueControllerFunction;
+		}
+
+		public MapOptionEntry<S, T> create(Map.Entry<S, T> initialValue) {
+			return new MapOptionEntryImpl<>(MapOptionImpl.this, initialValue, keyControllerFunction, valueControllerFunction);
+		}
+	}
+
+	public static final class BuilderImpl<S, T> implements Builder<S, T> {
+		private Component name = Component.empty();
+		private OptionDescription description = OptionDescription.EMPTY;
+		private Function<MapOptionEntry<S, T>, Controller<S>> keyControllerFunction;
+		private Function<MapOptionEntry<S, T>, Controller<T>> valueControllerFunction;
+		private Binding<Map<S, T>> binding = null;
+		private final Set<OptionFlag> flags = new HashSet<>();
+		private Supplier<Map.Entry<S, T>> initialValue;
+		private boolean collapsed = false;
+		private boolean available = true;
+		private int minimumNumberOfEntries = 0;
+		private int maximumNumberOfEntries = Integer.MAX_VALUE;
+		private boolean insertEntriesAtEnd = false;
+		private final List<BiConsumer<Option<Map<S, T>>, Map<S, T>>> listeners = new ArrayList<>();
+
+		@Override
+		public Builder<S, T> name(@NotNull Component name) {
+			Validate.notNull(name, "`name` must not be null");
+
+			this.name = name;
+			return this;
+		}
+
+		@Override
+		public Builder<S, T> description(@NotNull OptionDescription description) {
+			Validate.notNull(description, "`description` must not be null");
+
+			this.description = description;
+			return this;
+		}
+
+		@Override
+		public Builder<S, T> initial(@NotNull Supplier<Map.Entry<S, T>> initialValue) {
+			Validate.notNull(initialValue, "`initialValue` cannot be empty");
+
+			this.initialValue = initialValue;
+			return this;
+		}
+
+		@Override
+		public Builder<S, T> initial(@NotNull Map.Entry<S, T> initialValue) {
+			Validate.notNull(initialValue, "`initialValue` cannot be empty");
+
+			this.initialValue = () -> initialValue;
+			return this;
+		}
+
+		@Override
+		public Builder<S, T> keyController(@NotNull Function<MapOptionEntry<S, T>, ControllerBuilder<S>> controller) {
+			Validate.notNull(controller, "`controller` cannot be null");
+
+			this.keyControllerFunction = opt -> controller.apply(opt).build();
+			return this;
+		}
+
+		@Override
+		public Builder<S, T> valueController(@NotNull Function<MapOptionEntry<S, T>, ControllerBuilder<T>> controller) {
+			Validate.notNull(controller, "`controller` cannot be null");
+
+			this.valueControllerFunction = opt -> controller.apply(opt).build();
+			return this;
+		}
+
+		@Override
+		public Builder<S, T> customController(@NotNull Function<MapOptionEntry<S, T>, Controller<S>> keyControl, @NotNull Function<MapOptionEntry<S, T>, Controller<T>> valueControl) {
+			Validate.notNull(keyControl, "`keyControl` cannot be null");
+			Validate.notNull(valueControl, "`valueControl` cannot be null");
+
+			this.keyControllerFunction = keyControl;
+			this.valueControllerFunction = valueControl;
+			return this;
+		}
+
+		@Override
+		public Builder<S, T> binding(@NotNull Binding<Map<S, T>> binding) {
+			Validate.notNull(binding, "`binding` cannot be null");
+
+			this.binding = binding;
+			return this;
+		}
+
+		@Override
+		public Builder<S, T> binding(@NotNull Map<S, T> def, @NotNull Supplier<@NotNull Map<S, T>> getter, @NotNull Consumer<@NotNull Map<S, T>> setter) {
+			Validate.notNull(def, "`def` must not be null");
+			Validate.notNull(getter, "`getter` must not be null");
+			Validate.notNull(setter, "`setter` must not be null");
+
+			this.binding = Binding.generic(def, getter, setter);
+			return this;
+		}
+
+		@Override
+		public Builder<S, T> available(boolean available) {
+			this.available = available;
+			return this;
+		}
+
+		@Override
+		public Builder<S, T> minimumNumberOfEntries(int number) {
+			this.minimumNumberOfEntries = number;
+			return this;
+		}
+
+		@Override
+		public Builder<S, T> maximumNumberOfEntries(int number) {
+			this.maximumNumberOfEntries = number;
+			return this;
+		}
+
+		@Override
+		public Builder<S, T> insertEntriesAtEnd(boolean insertAtEnd) {
+			this.insertEntriesAtEnd = insertAtEnd;
+			return this;
+		}
+
+		@Override
+		public Builder<S, T> flag(@NotNull OptionFlag... flag) {
+			Validate.notNull(flag, "`flag` must not be null");
+
+			this.flags.addAll(Arrays.asList(flag));
+			return this;
+		}
+
+		@Override
+		public Builder<S, T> flags(@NotNull Collection<OptionFlag> flags) {
+			Validate.notNull(flags, "`flags` must not be null");
+
+			this.flags.addAll(flags);
+			return this;
+		}
+
+		@Override
+		public Builder<S, T> collapsed(boolean collapsible) {
+			this.collapsed = collapsible;
+			return this;
+		}
+
+		@Override
+		public Builder<S, T> listener(@NotNull BiConsumer<Option<Map<S, T>>, Map<S, T>> listener) {
+			this.listeners.add(listener);
+			return this;
+		}
+
+		@Override
+		public Builder<S, T> listeners(@NotNull Collection<BiConsumer<Option<Map<S, T>>, Map<S, T>>> listeners) {
+			this.listeners.addAll(listeners);
+			return this;
+		}
+
+		@Override
+		public MapOption<S, T> build() {
+			Validate.notNull(keyControllerFunction, "`keyController` must not be null");
+			Validate.notNull(valueControllerFunction, "`valueController` must not be null");
+			Validate.notNull(binding, "`binding` must not be null");
+			Validate.notNull(initialValue, "`initialValue` must not be null");
+
+			return new MapOptionImpl<>(name, description, binding, initialValue, keyControllerFunction, valueControllerFunction,
+					ImmutableSet.copyOf(flags), collapsed, available, minimumNumberOfEntries, maximumNumberOfEntries, insertEntriesAtEnd,
+					listeners
+			);
+		}
+	}
+}

--- a/test-common/src/main/java/dev/isxander/yacl3/test/ConfigTest.java
+++ b/test-common/src/main/java/dev/isxander/yacl3/test/ConfigTest.java
@@ -9,6 +9,7 @@ import net.minecraft.world.item.Items;
 
 import java.awt.*;
 import java.util.List;
+import java.util.Map;
 
 public class ConfigTest {
     public static final ConfigClassHandler<ConfigTest> GSON = ConfigClassHandler.createBuilder(ConfigTest.class)
@@ -56,6 +57,9 @@ public class ConfigTest {
     public List<String> stringList = List.of("This is quite cool.", "You can add multiple items!", "And it is integrated so well into Option groups!");
     @SerialEntry
     public List<Integer> intList = List.of(1, 2, 3);
+
+    @SerialEntry
+    public Map<String, String> stringMap = Map.of("Key", "Value", "This is a map!", "Fully integrated just like lists.");
 
     @SerialEntry
     public boolean groupTestRoot = false;

--- a/test-common/src/main/java/dev/isxander/yacl3/test/GuiTest.java
+++ b/test-common/src/main/java/dev/isxander/yacl3/test/GuiTest.java
@@ -27,7 +27,9 @@ import net.minecraft.world.item.Item;
 
 import java.awt.Color;
 import java.nio.file.Path;
+import java.util.AbstractMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class GuiTest {
@@ -334,6 +336,29 @@ public class GuiTest {
                                         .initial(Component.literal("Initial label"))
                                         .build())
                                 .build())
+                        .category(ConfigCategory.createBuilder()
+                                .name(Component.literal("Map Test"))
+                                .group(MapOption.<String, String>createBuilder()
+                                                                 .name(Component.literal("String Map"))
+                                                                 .binding(
+                                                                         defaults.stringMap,
+                                                                         () -> config.stringMap,
+                                                                         val -> config.stringMap = val
+                                                                 )
+                                                                 .keyController(StringControllerBuilder::create)
+                                                                 .valueController(StringControllerBuilder::create)
+                                                                 .initial(Map.entry("", ""))
+                                                                 .minimumNumberOfEntries(3)
+                                                                 .maximumNumberOfEntries(5)
+                                                                 .insertEntriesAtEnd(true)
+                                                                 .build())
+                                                .group(MapOption.<Component, Component>createBuilder()
+                                                                 .name(Component.literal("Useless Label Map"))
+                                                                 .binding(Binding.immutable(Map.of(Component.literal("It's quite impressive that literally every single controller works, without problem."), Component.literal("It's quite impressive that literally every single controller works, without problem."))))
+                                                                 .customController(LabelController::new, LabelController::new)
+                                                                 .initial(Map.entry(Component.literal("Initial key label"), Component.literal("Initial value label")))
+                                                                 .build())
+                                                .build())
                         .category(ConfigCategory.createBuilder()
                                 .name(Component.literal("Group Test"))
                                 .option(Option.createBuilder(boolean.class)


### PR DESCRIPTION
Adds support for `Map`s, with any existing controller type as a supported key/value controller.
I left 2 TODO comments in the code, for some slightly cursed stuff that I don't know how to handle.

I still need to add a GUI element for the values of entries. Currently only keys are displayed.
This is also in part due to the TODO comments mentioned before.

Feel free to suggest improvements and changes.
