### PR TITLE
Propagate right click mouse events to widgets contained in option lists

### DIFF
--- a/src/main/java/dev/isxander/yacl3/gui/ElementListWidgetExt.java
+++ b/src/main/java/dev/isxander/yacl3/gui/ElementListWidgetExt.java
@@ -10,6 +10,7 @@ import net.minecraft.client.gui.layouts.LayoutElement;
 import net.minecraft.client.gui.navigation.ScreenRectangle;
 import net.minecraft.util.Mth;
 import org.jetbrains.annotations.Nullable;
+import org.lwjgl.glfw.GLFW;
 
 import java.util.function.Consumer;
 
@@ -78,6 +79,13 @@ public class ElementListWidgetExt<E extends ElementListWidgetExt.Entry<E>> exten
 
         returnSmoothAmount = false;
     }
+
+    /*? if >1.20.1 { */
+    @Override
+    protected boolean isValidMouseClick(int button) {
+        return button == InputConstants.MOUSE_BUTTON_LEFT || button == InputConstants.MOUSE_BUTTON_RIGHT;
+    }
+    /*?}*/
 
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {

--- a/src/main/java/dev/isxander/yacl3/gui/ElementListWidgetExt.java
+++ b/src/main/java/dev/isxander/yacl3/gui/ElementListWidgetExt.java
@@ -223,7 +223,7 @@ public class ElementListWidgetExt<E extends ElementListWidgetExt.Entry<E>> exten
         public boolean mouseClicked(double mouseX, double mouseY, int button) {
             for (GuiEventListener child : this.children()) {
                 if (child.mouseClicked(mouseX, mouseY, button)) {
-                    if (button == InputConstants.MOUSE_BUTTON_LEFT)
+                    if (button == InputConstants.MOUSE_BUTTON_LEFT || button == InputConstants.MOUSE_BUTTON_RIGHT)
                         this.setDragging(true);
                     return true;
                 }
@@ -234,7 +234,7 @@ public class ElementListWidgetExt<E extends ElementListWidgetExt.Entry<E>> exten
 
         @Override
         public boolean mouseDragged(double mouseX, double mouseY, int button, double deltaX, double deltaY) {
-            if (isDragging() && button == InputConstants.MOUSE_BUTTON_LEFT) {
+            if (isDragging() && (button == InputConstants.MOUSE_BUTTON_LEFT || button == InputConstants.MOUSE_BUTTON_RIGHT)) {
                 for (GuiEventListener child : this.children()) {
                     if (child.mouseDragged(mouseX, mouseY, button, deltaX, deltaY))
                         return true;

--- a/src/main/java/dev/isxander/yacl3/gui/OptionListWidget.java
+++ b/src/main/java/dev/isxander/yacl3/gui/OptionListWidget.java
@@ -1,6 +1,7 @@
 package dev.isxander.yacl3.gui;
 
 import com.google.common.collect.ImmutableList;
+import com.mojang.blaze3d.platform.InputConstants;
 import dev.isxander.yacl3.api.*;
 import dev.isxander.yacl3.api.utils.Dimension;
 import dev.isxander.yacl3.impl.utils.YACLConstants;
@@ -164,6 +165,19 @@ public class OptionListWidget extends ElementListWidgetExt<OptionListWidget.Entr
         }
 
         return true;
+    }
+
+    @Override
+    protected boolean isValidClickButton(int button) {
+        return button == InputConstants.MOUSE_BUTTON_LEFT || button == InputConstants.MOUSE_BUTTON_RIGHT;
+    }
+
+    @Override
+    public boolean mouseDragged(double mouseX, double mouseY, int button, double deltaX, double deltaY) {
+        if (this.getFocused() != null && this.isDragging() && isValidClickButton(button)) {
+            return this.getFocused().mouseDragged(mouseX, mouseY, button, deltaX, deltaY);
+        }
+        return super.mouseDragged(mouseX, mouseY, button, deltaX, deltaY);
     }
 
     @Override

--- a/src/main/java/dev/isxander/yacl3/gui/YACLScreen.java
+++ b/src/main/java/dev/isxander/yacl3/gui/YACLScreen.java
@@ -1,5 +1,6 @@
 package dev.isxander.yacl3.gui;
 
+import com.mojang.blaze3d.platform.InputConstants;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.*;
 import com.mojang.math.Axis;
@@ -201,6 +202,23 @@ public class YACLScreen extends Screen {
                 }
             }
         }
+    }
+
+    @Override
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        if (super.mouseClicked(mouseX, mouseY, button)) {
+            this.setDragging(true);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean mouseDragged(double mouseX, double mouseY, int button, double deltaX, double deltaY) {
+        return this.getFocused() != null
+                && this.isDragging()
+                && (button == InputConstants.MOUSE_BUTTON_LEFT || button == InputConstants.MOUSE_BUTTON_RIGHT)
+                && this.getFocused().mouseDragged(mouseX, mouseY, button, deltaX, deltaY);
     }
 
     public void setSaveButtonMessage(Component message, Component tooltip) {


### PR DESCRIPTION
Starting with Minecraft 1.20.2, only left click events are passed to list elements. This adds the required override to the respective versions to get right click events.

With this change, right-clicking a cycling controller (like enum controller) element properly walks backwards through the list.

Closes #157 