### PR TITLE
Allow accessing the cancel/reset and undo buttons

### DIFF
--- a/src/main/java/dev/isxander/yacl3/gui/YACLScreen.java
+++ b/src/main/java/dev/isxander/yacl3/gui/YACLScreen.java
@@ -314,8 +314,8 @@ public class YACLScreen extends Screen {
 
         private ListHolderWidget<OptionListWidget> optionList;
         public final Button saveFinishedButton;
-        private final Button cancelResetButton;
-        private final Button undoButton;
+        public final Button cancelResetButton;
+        public final Button undoButton;
         private final SearchFieldWidget searchField;
         private OptionDescriptionWidget descriptionWidget;
 


### PR DESCRIPTION
I want to temporarily disable the main yacl buttons (especially "Undo") to prevent confusion.