### PR TITLE
Fix dropdown controllers erroneously showing their dropdown

### DIFF
--- a/src/main/java/dev/isxander/yacl3/gui/controllers/dropdown/AbstractDropdownControllerElement.java
+++ b/src/main/java/dev/isxander/yacl3/gui/controllers/dropdown/AbstractDropdownControllerElement.java
@@ -104,6 +104,9 @@ public abstract class AbstractDropdownControllerElement<T, U> extends StringCont
 
 	@Override
 	public boolean charTyped(char chr, int modifiers) {
+		if (!inputFieldFocused) {
+			return false;
+		}
 		if (!dropdownVisible) {
 			createDropdownWidget();
 		}


### PR DESCRIPTION
Whenever a text input followed a dropdown controller, the dropdown controller would act on the key press and show its widget.