### PR TITLE
Fix default min values for floating point field controllers

### DIFF
--- a/src/main/java/dev/isxander/yacl3/impl/controller/DoubleFieldControllerBuilderImpl.java
+++ b/src/main/java/dev/isxander/yacl3/impl/controller/DoubleFieldControllerBuilderImpl.java
@@ -11,7 +11,7 @@ import net.minecraft.network.chat.Component;
 import java.util.function.Function;
 
 public class DoubleFieldControllerBuilderImpl extends AbstractControllerBuilderImpl<Double> implements DoubleFieldControllerBuilder {
-    private double min = Double.MIN_VALUE;
+    private double min = -Double.MAX_VALUE;
     private double max = Double.MAX_VALUE;
     private ValueFormatter<Double> formatter = DoubleSliderController.DEFAULT_FORMATTER::apply;
 

--- a/src/main/java/dev/isxander/yacl3/impl/controller/FloatFieldControllerBuilderImpl.java
+++ b/src/main/java/dev/isxander/yacl3/impl/controller/FloatFieldControllerBuilderImpl.java
@@ -11,7 +11,7 @@ import net.minecraft.network.chat.Component;
 import java.util.function.Function;
 
 public class FloatFieldControllerBuilderImpl extends AbstractControllerBuilderImpl<Float> implements FloatFieldControllerBuilder {
-    private float min = Float.MIN_VALUE;
+    private float min = -Float.MAX_VALUE;
     private float max = Float.MAX_VALUE;
     private ValueFormatter<Float> formatter = FloatSliderController.DEFAULT_FORMATTER::apply;
 


### PR DESCRIPTION
Changes the default minimum values for the `FloatFieldControllerBuilderImpl` and `DoubleFieldControllerBuilderImpl` classes to the minimum *negative* possible values, instead of the minimum non-zero positive possible value.

These are now consistent with `FloatFieldController` and `DoubleFieldController`.