### PR TITLE
Add middle-mouse clicks as a valid button for ElementListWidgetExt

### DIFF
--- a/src/main/java/dev/isxander/yacl3/gui/ElementListWidgetExt.java
+++ b/src/main/java/dev/isxander/yacl3/gui/ElementListWidgetExt.java
@@ -88,7 +88,7 @@ public class ElementListWidgetExt<E extends ElementListWidgetExt.Entry<E>> exten
     @Override
     /*?}*/
     protected boolean isValidMouseClick(int button) {
-        return button == InputConstants.MOUSE_BUTTON_LEFT || button == InputConstants.MOUSE_BUTTON_RIGHT;
+        return button == InputConstants.MOUSE_BUTTON_LEFT || button == InputConstants.MOUSE_BUTTON_RIGHT || button == InputConstants.MOUSE_BUTTON_MIDDLE;
     }
 
     @Override


### PR DESCRIPTION
This means the button is also permitted for any child element, since the click it passed down. Solves #207.