### PR TITLE
Handle nullable style in label controller

### DIFF
--- a/src/main/java/dev/isxander/yacl3/gui/controllers/LabelController.java
+++ b/src/main/java/dev/isxander/yacl3/gui/controllers/LabelController.java
@@ -146,6 +146,10 @@ public class LabelController implements Controller<Component> {
                 return false;
 
             Style style = getStyle((int) mouseX, (int) mouseY);
+
+            if(style == null)
+                return false;
+
             return screen.handleComponentClicked(style);
         }
 

--- a/src/main/java/dev/isxander/yacl3/gui/controllers/LabelController.java
+++ b/src/main/java/dev/isxander/yacl3/gui/controllers/LabelController.java
@@ -153,6 +153,7 @@ public class LabelController implements Controller<Component> {
             return screen.handleComponentClicked(style);
         }
 
+        @Nullable
         protected Style getStyle(int mouseX, int mouseY) {
             if (!getDimension().isPointInside(mouseX, mouseY))
                 return null;


### PR DESCRIPTION
This should fix:
```
Description: mouseClicked event handler

java.lang.NullPointerException: Cannot invoke "net.minecraft.class_2583.method_10970()" because "$$0" is null
```

Since the `getStyle()` in `LabelController.mouseClicked` method can return `null`.

Related issues:
- https://github.com/isXander/YetAnotherConfigLib/issues/287
- https://github.com/Faboslav/structurify/issues/35
- https://github.com/Faboslav/structurify/issues/32