### PR TITLE
Fix "List is empty" string

### DIFF
--- a/src/main/java/dev/isxander/yacl3/gui/OptionListWidget.java
+++ b/src/main/java/dev/isxander/yacl3/gui/OptionListWidget.java
@@ -630,6 +630,10 @@ public class OptionListWidget extends YACLSelectionList<OptionListWidget.Entry> 
 
         @Override
         public void renderContent(GuiGraphics graphics, int mouseX, int mouseY, boolean hovered, float deltaTicks) {
+            if (!this.isViewable()) {
+                return;
+            }
+
             graphics.drawCenteredString(Minecraft.getInstance().font, Component.translatable("yacl.list.empty").withStyle(ChatFormatting.DARK_GRAY, ChatFormatting.ITALIC), this.getX() + this.getWidth() / 2, this.getY(), -1);
         }
 
@@ -641,6 +645,12 @@ public class OptionListWidget extends YACLSelectionList<OptionListWidget.Entry> 
         @Override
         public boolean isViewable() {
             return parent.isExpanded() && super.isViewable();
+        }
+
+        @Override
+        protected void onBecameViewable() {
+            super.onBecameViewable();
+            setHeight(11);
         }
 
         @Override


### PR DESCRIPTION
Fixes the `List is empty` String (`yacl.list.empty`) from `OptionListWidget.EmptyListLabel` neither being expanded nor collapsed correctly. 
For an example of the issue see the screenshot below. Looks exactly the same with the list expanded instead of collapsed.
Fix has been tested on fabric 1.21.11 with all versions building without errors.

<img width="531" height="85" alt="image" src="https://github.com/user-attachments/assets/b402e5a7-3af6-4efe-9074-1e91f87081a7" />
