### PR TITLE
Mark as requiring Fabric >=0.18.0

### DIFF
--- a/src/main/templates/fabric.mod.json
+++ b/src/main/templates/fabric.mod.json
@@ -16,7 +16,7 @@
   "license": "${mod_license}",
   "environment": "*",
   "depends": {
-    "fabricloader": ">=0.17.0",
+    "fabricloader": ">=0.18.0",
     "minecraft": "${mc}",
     "java": ">=17",
     "fabric-api": ">=${fapi}"


### PR DESCRIPTION
YACL uses 0.18 features, so it should declare that to let users know.