### PR TITLE
Bump Fabric Loader requirement to 0.18.0

### DIFF
--- a/src/main/templates/fabric.mod.json
+++ b/src/main/templates/fabric.mod.json
@@ -16,7 +16,7 @@
   "license": "${mod_license}",
   "environment": "*",
   "depends": {
-    "fabricloader": ">=0.17.0",
+    "fabricloader": ">=0.18.0",
     "minecraft": "${mc}",
     "java": ">=17",
     "fabric-api": ">=${fapi}"


### PR DESCRIPTION
The new classTweaker crashes with older Fabric Loader, at least version 3.8.2 on Minecraft 1.21.10.

Let me know if there is a better way to handle this, because I don't quite know how your modstitch stuff works.