### PR TITLE
Add ability to add descriptions to autogen groups

### DIFF
--- a/src/main/java/dev/isxander/yacl3/config/v2/impl/ConfigClassHandlerImpl.java
+++ b/src/main/java/dev/isxander/yacl3/config/v2/impl/ConfigClassHandlerImpl.java
@@ -10,6 +10,7 @@ import dev.isxander.yacl3.config.v2.impl.autogen.OptionAccessImpl;
 import dev.isxander.yacl3.config.v2.impl.autogen.YACLAutoGenException;
 import dev.isxander.yacl3.impl.utils.YACLConstants;
 import dev.isxander.yacl3.platform.YACLPlatform;
+import net.minecraft.locale.Language;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 import org.apache.commons.lang3.Validate;
@@ -134,8 +135,14 @@ public class ConfigClassHandlerImpl<T> implements ConfigClassHandler<T> {
                 OptionAddable group = groups.groups().computeIfAbsent(autoGen.group().orElse(""), k -> {
                     if (k.isEmpty())
                         return groups.category();
-                    return OptionGroup.createBuilder()
-                            .name(Component.translatable("yacl3.config.%s.category.%s.group.%s".formatted(id().toString(), autoGen.category(), k)));
+                    String groupKey = "yacl3.config.%s.category.%s.group.%s".formatted(id().toString(), autoGen.category(), k);
+                    OptionGroup.Builder groupBuilder = OptionGroup.createBuilder()
+                            .name(Component.translatable(groupKey));
+                    String descriptionKey = groupKey + ".desc";
+                    if (Language.getInstance().has(descriptionKey)) {
+                        groupBuilder.description(OptionDescription.of(Component.translatable(descriptionKey)));
+                    }
+                    return groupBuilder;
                 });
 
                 Option<?> option;

--- a/src/testmod/resources/assets/yacl_test/lang/en_us.json
+++ b/src/testmod/resources/assets/yacl_test/lang/en_us.json
@@ -1,0 +1,4 @@
+{
+    "yacl3.config.yacl3-test:config.category.test.group.master_test": "My group!",
+    "yacl3.config.yacl3-test:config.category.test.group.master_test.desc": "This group has a description via a translation key."
+}


### PR DESCRIPTION
I added the ability to add descriptions to groups generated with autogen by using translation keys, similar to how you can add descriptions to fields. If there's no key, there will be no description.

I also added a few translation keys to the testmod to check that the description is working.

