### PR TITLE
Fix integer formatting in autogen integer/long fields and sliders

### DIFF
--- a/src/main/java/dev/isxander/yacl3/config/v2/api/autogen/IntField.java
+++ b/src/main/java/dev/isxander/yacl3/config/v2/api/autogen/IntField.java
@@ -37,5 +37,5 @@ public @interface IntField {
      * The format used to display the integer.
      * This is the syntax used in {@link String#format(String, Object...)}.
      */
-    String format() default "%.0f";
+    String format() default "%d";
 }

--- a/src/main/java/dev/isxander/yacl3/config/v2/api/autogen/IntSlider.java
+++ b/src/main/java/dev/isxander/yacl3/config/v2/api/autogen/IntSlider.java
@@ -28,8 +28,17 @@ public @interface IntSlider {
     int max();
 
     /**
+     * The step size of this slider.
+     * <p>
+     * For example, if this is set to 1, the slider will
+     * increment/decrement by 1 when dragging, no less, no more and
+     * will always be a multiple of 1.
+     */
+    int step();
+
+    /**
      * The format used to display the integer.
      * This is the syntax used in {@link String#format(String, Object...)}.
      */
-    int step();
+    String format() default "%d";
 }

--- a/src/main/java/dev/isxander/yacl3/config/v2/api/autogen/LongField.java
+++ b/src/main/java/dev/isxander/yacl3/config/v2/api/autogen/LongField.java
@@ -37,5 +37,5 @@ public @interface LongField {
      * The format used to display the long.
      * This is the syntax used in {@link String#format(String, Object...)}.
      */
-    String format() default "%.0f";
+    String format() default "%d";
 }

--- a/src/main/java/dev/isxander/yacl3/config/v2/api/autogen/LongSlider.java
+++ b/src/main/java/dev/isxander/yacl3/config/v2/api/autogen/LongSlider.java
@@ -28,8 +28,17 @@ public @interface LongSlider {
     long max();
 
     /**
-     * The format used to display the integer.
-     * This is the syntax used in {@link String#format(String, Object...)}.
+     * The step size of this slider.
+     * <p>
+     * For example, if this is set to 1, the slider will
+     * increment/decrement by 1 when dragging, no less, no more and
+     * will always be a multiple of 1.
      */
     long step();
+
+    /**
+     * The format used to display the long.
+     * This is the syntax used in {@link String#format(String, Object...)}.
+     */
+    String format() default "%d";
 }

--- a/src/main/java/dev/isxander/yacl3/config/v2/impl/autogen/IntFieldImpl.java
+++ b/src/main/java/dev/isxander/yacl3/config/v2/impl/autogen/IntFieldImpl.java
@@ -21,7 +21,7 @@ public class IntFieldImpl extends SimpleOptionFactory<IntField, Integer> {
                     key = getTranslationKey(field, "fmt");
                     if (Language.getInstance().has(key))
                         return Component.translatable(key, v);
-                    return Component.literal(Integer.toString(v));
+                    return Component.literal(String.format(annotation.format(), v));
                 })
                 .range(annotation.min(), annotation.max());
     }

--- a/src/main/java/dev/isxander/yacl3/config/v2/impl/autogen/IntSliderImpl.java
+++ b/src/main/java/dev/isxander/yacl3/config/v2/impl/autogen/IntSliderImpl.java
@@ -21,7 +21,7 @@ public class IntSliderImpl extends SimpleOptionFactory<IntSlider, Integer> {
                     key = getTranslationKey(field, "fmt");
                     if (Language.getInstance().has(key))
                         return Component.translatable(key, v);
-                    return Component.literal(Integer.toString(v));
+                    return Component.literal(String.format(annotation.format(), v));
                 })
                 .range(annotation.min(), annotation.max())
                 .step(annotation.step());

--- a/src/main/java/dev/isxander/yacl3/config/v2/impl/autogen/LongFieldImpl.java
+++ b/src/main/java/dev/isxander/yacl3/config/v2/impl/autogen/LongFieldImpl.java
@@ -21,7 +21,7 @@ public class LongFieldImpl extends SimpleOptionFactory<LongField, Long> {
                     key = getTranslationKey(field, "fmt");
                     if (Language.getInstance().has(key))
                         return Component.translatable(key, v);
-                    return Component.literal(Long.toString(v));
+                    return Component.literal(String.format(annotation.format(), v));
                 })
                 .range(annotation.min(), annotation.max());
     }

--- a/src/main/java/dev/isxander/yacl3/config/v2/impl/autogen/LongSliderImpl.java
+++ b/src/main/java/dev/isxander/yacl3/config/v2/impl/autogen/LongSliderImpl.java
@@ -21,7 +21,7 @@ public class LongSliderImpl extends SimpleOptionFactory<LongSlider, Long> {
                     key = getTranslationKey(field, "fmt");
                     if (Language.getInstance().has(key))
                         return Component.translatable(key, v);
-                    return Component.literal(Long.toString(v));
+                    return Component.literal(String.format(annotation.format(), v));
                 })
                 .range(annotation.min(), annotation.max())
                 .step(annotation.step());

--- a/src/testmod/java/dev/isxander/yacl3/test/AutogenConfigTest.java
+++ b/src/testmod/java/dev/isxander/yacl3/test/AutogenConfigTest.java
@@ -32,7 +32,7 @@ public class AutogenConfigTest {
             .build();
 
     @AutoGen(category = "test", group = "master_test")
-    @MasterTickBox({ "testTickBox", "testBoolean", "testInt", "testDouble", "testFloat", "testLong", "testIntField", "testDoubleField", "testFloatField", "testLongField", "testEnum", "testColor", "testString", "testDropdown", "testItem" })
+    @MasterTickBox({ "testTickBox", "testBoolean", "testInt", "testDouble", "testFloat", "testLong", "testLongFormatted", "testIntField", "testDoubleField", "testFloatField", "testLongField", "testEnum", "testColor", "testString", "testDropdown", "testItem" })
     @SerialEntry(comment = "This option disables all the other options in this group")
     public boolean masterOption = true;
 

--- a/src/testmod/java/dev/isxander/yacl3/test/AutogenConfigTest.java
+++ b/src/testmod/java/dev/isxander/yacl3/test/AutogenConfigTest.java
@@ -65,6 +65,10 @@ public class AutogenConfigTest {
     @SerialEntry public long testLong = 0;
 
     @AutoGen(category = "test", group = "master_test")
+    @LongSlider(min = 0, max = 1000, step = 10, format = "%dms")
+    @SerialEntry public long testLongFormatted = 500;
+
+    @AutoGen(category = "test", group = "master_test")
     @IntField(min = 0, max = 10)
     @SerialEntry public int testIntField = 0;
 


### PR DESCRIPTION
`IntField` and `LongField` had `format` fields but they were not used. So I made them be used properly and also added `format` fields to `IntSlider` and `LongSlider` (which also had the javadoc for `format`, but on `step` for some reason, so I fixed that aswell).