### PR TITLE
Fixed an issue where string options do not support IME on >=26.1

### DIFF
--- a/src/main/java/dev/isxander/yacl3/gui/OptionListWidget.java
+++ b/src/main/java/dev/isxander/yacl3/gui/OptionListWidget.java
@@ -21,6 +21,7 @@ import net.minecraft.client.gui.TextAlignment;
 import net.minecraft.client.input.CharacterEvent;
 import net.minecraft.client.input.KeyEvent;
 import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.client.input.PreeditEvent;
 import net.minecraft.network.chat.Component;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -211,6 +212,16 @@ public class OptionListWidget extends YACLSelectionList<OptionListWidget.Entry> 
         return super.charTyped(characterEvent);
     }
 
+    @Override
+    public boolean preeditUpdated(@Nullable PreeditEvent event) {
+        for (Entry child : children()) {
+            if (child.preeditUpdated(event))
+                return true;
+        }
+
+        return super.preeditUpdated(event);
+    }
+
     private List<Entry> superModifiableChildren() {
         // noinspection unchecked
         return (List<Entry>) ((AbstractSelectionListAccessor) this).getChildren();
@@ -299,6 +310,10 @@ public class OptionListWidget extends YACLSelectionList<OptionListWidget.Entry> 
         protected void onBecameHidden() {
             this.setHeight(0);
         }
+
+        public boolean preeditUpdated(@Nullable PreeditEvent event) {
+            return false;
+        }
     }
 
     public class OptionEntry extends Entry {
@@ -371,6 +386,11 @@ public class OptionListWidget extends YACLSelectionList<OptionListWidget.Entry> 
         @Override
         public boolean charTyped(@NonNull CharacterEvent event) {
             return widget.charTyped(event);
+        }
+
+        @Override
+        public boolean preeditUpdated(@Nullable PreeditEvent event) {
+            return widget.preeditUpdated(event);
         }
 
         @Override

--- a/src/main/java/dev/isxander/yacl3/gui/controllers/ListEntryWidget.java
+++ b/src/main/java/dev/isxander/yacl3/gui/controllers/ListEntryWidget.java
@@ -14,6 +14,7 @@ import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.client.input.CharacterEvent;
 import net.minecraft.client.input.KeyEvent;
 import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.client.input.PreeditEvent;
 import net.minecraft.network.chat.Component;
 import org.jetbrains.annotations.Nullable;
 import org.jspecify.annotations.NonNull;
@@ -158,5 +159,12 @@ public class ListEntryWidget extends AbstractWidget implements ContainerEventHan
     @Override
     public boolean charTyped(CharacterEvent characterEvent) {
         return ContainerEventHandler.super.charTyped(characterEvent);
+    }
+
+    @Override
+    public boolean preeditUpdated(@Nullable PreeditEvent event) {
+        if (entryWidget.preeditUpdated(event))
+            return true;
+        return ContainerEventHandler.super.preeditUpdated(event);
     }
 }

--- a/src/main/java/dev/isxander/yacl3/gui/controllers/PopupControllerScreen.java
+++ b/src/main/java/dev/isxander/yacl3/gui/controllers/PopupControllerScreen.java
@@ -8,6 +8,8 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.input.CharacterEvent;
 import net.minecraft.client.input.KeyEvent;
 import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.client.input.PreeditEvent;
+import org.jetbrains.annotations.Nullable;
 import org.jspecify.annotations.NonNull;
 
 public class PopupControllerScreen extends Screen {
@@ -76,6 +78,11 @@ public class PopupControllerScreen extends Screen {
     @Override
     public boolean charTyped(@NonNull CharacterEvent characterEvent) {
         return controllerPopup.charTyped(characterEvent);
+    }
+
+    @Override
+    public boolean preeditUpdated(@Nullable PreeditEvent event) {
+        return controllerPopup.preeditUpdated(event);
     }
 
     @Override

--- a/src/main/java/dev/isxander/yacl3/gui/controllers/string/StringControllerElement.java
+++ b/src/main/java/dev/isxander/yacl3/gui/controllers/string/StringControllerElement.java
@@ -10,10 +10,13 @@ import dev.isxander.yacl3.gui.utils.KeyUtils;
 import dev.isxander.yacl3.gui.utils.UndoRedoHelper;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.IMEPreeditOverlay;
 import net.minecraft.client.input.CharacterEvent;
 import net.minecraft.client.input.KeyEvent;
 import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.client.input.PreeditEvent;
 import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.Nullable;
 import org.jspecify.annotations.NonNull;
 
 import java.util.function.Consumer;
@@ -36,6 +39,8 @@ public class StringControllerElement extends ControllerWidget<IStringController<
     protected float caretTicks;
 
     private final Component emptyText;
+
+    private @Nullable IMEPreeditOverlay preeditOverlay;
 
     public StringControllerElement(IStringController<?> control, YACLScreen screen, Dimension<Integer> dim, boolean instantApply) {
         super(control, screen, dim);
@@ -103,6 +108,14 @@ public class StringControllerElement extends ControllerWidget<IStringController<
         } else if (this.hovered) {
             graphics.requestCursor(isAvailable() ? com.mojang.blaze3d.platform.cursor.CursorTypes.POINTING_HAND : com.mojang.blaze3d.platform.cursor.CursorTypes.NOT_ALLOWED);
         }
+
+        if (preeditOverlay != null && inputFieldFocused) {
+            String text = getValueText().getString();
+            int preeditTextX = getDimension().xLimit() - textRenderer.width(getValueText()) + renderOffset - getXPadding();
+            int preeditCaretX = preeditTextX + textRenderer.width(text.substring(0, Math.min(caretPos, text.length())));
+            preeditOverlay.updateInputPosition(preeditCaretX, getTextY());
+            graphics.setPreeditOverlay(preeditOverlay);
+        }
     }
 
     private boolean isHoveredInputField(double mouseX, double mouseY) {
@@ -112,7 +125,7 @@ public class StringControllerElement extends ControllerWidget<IStringController<
     @Override
     public boolean mouseClicked(@NonNull MouseButtonEvent event, boolean doubleClick) {
         if (isAvailable() && getDimension().isPointInside((int) event.x(), (int) event.y())) {
-            inputFieldFocused = true;
+            setInputEditing(true);
 
             if (!isHoveredInputField(event.x(), event.y())) {
                 caretPos = getDefaultCaretPos();
@@ -322,13 +335,28 @@ public class StringControllerElement extends ControllerWidget<IStringController<
         }
     }
 
+    public boolean canConsumeInput() {
+        return inputFieldFocused && isAvailable();
+    }
+
     @Override
     public boolean charTyped(@NonNull CharacterEvent event) {
-        if (!inputFieldFocused)
+        if (!canConsumeInput())
             return false;
 
         write(event.codepointAsString());
         updateUndoHistory();
+        return true;
+    }
+
+    @Override
+    public boolean preeditUpdated(@Nullable PreeditEvent event) {
+        if (!canConsumeInput())
+            return false;
+
+        preeditOverlay = event != null
+                ? new IMEPreeditOverlay(event, textRenderer, textRenderer.lineHeight + 1)
+                : null;
         return true;
     }
 
@@ -431,15 +459,25 @@ public class StringControllerElement extends ControllerWidget<IStringController<
     @Override
     public void setFocused(boolean focused) {
         super.setFocused(focused);
-        inputFieldFocused = focused;
+        setInputEditing(focused);
     }
 
     @Override
     public void unfocus() {
+        setInputEditing(false);
         super.unfocus();
-        inputFieldFocused = false;
         renderOffset = 0;
         if (!instantApply) updateControl();
+    }
+
+    private void setInputEditing(boolean editing) {
+        if (inputFieldFocused == editing)
+            return;
+
+        inputFieldFocused = editing;
+        client.onTextInputFocusChange(this, editing);
+        if (!editing)
+            preeditOverlay = null;
     }
 
     @Override


### PR DESCRIPTION
I found I can't input any Chinese using Chinese IME (e.g. Sogou Pinyin, Microsoft Pinyin) on string options when working on my project. Actually I can't switch the input language of IME to Chinese when focusing on string options. I doubted that the support to IME updated on 26.1 is the reason for the issue, so I fixed it.
I've tested the behavior on 26.1 Neoforge, 26.1 Fabric and 26.2 Fabric using Sogou Pinyin, and it works well.