### PR TITLE
Fix sliders & cycling controllers 26.3+ by using constants for mouse buttons (Fixes #348)

### DIFF
--- a/src/main/java/dev/isxander/yacl3/gui/controllers/cycling/CyclingControllerElement.java
+++ b/src/main/java/dev/isxander/yacl3/gui/controllers/cycling/CyclingControllerElement.java
@@ -36,13 +36,12 @@ public class CyclingControllerElement extends ControllerWidget<ICyclingControlle
     }
 
     @Override
-    public boolean mouseClicked(MouseButtonEvent event, boolean doubleClick) {
-        if (!isMouseOver(event.x(), event.y()) || (event.button() != 0 && event.button() != 1) || !isAvailable())
+    public boolean mouseClicked(@NonNull MouseButtonEvent event, boolean doubleClick) {
+        if (!isMouseOver(event.x(), event.y()) || (event.button() != InputConstants.MOUSE_BUTTON_LEFT && event.button() != InputConstants.MOUSE_BUTTON_RIGHT) || !isAvailable())
             return false;
 
         playDownSound();
-        cycleValue(event.button() == 1 || event.hasShiftDown() || event.hasControlDown() ? -1 : 1);
-
+        cycleValue(event.button() == InputConstants.MOUSE_BUTTON_RIGHT || event.hasShiftDown() || event.hasControlDown() ? -1 : 1);
         return true;
     }
 

--- a/src/main/java/dev/isxander/yacl3/gui/controllers/slider/SliderControllerElement.java
+++ b/src/main/java/dev/isxander/yacl3/gui/controllers/slider/SliderControllerElement.java
@@ -63,7 +63,7 @@ public class SliderControllerElement extends ControllerWidget<ISliderController<
 
     @Override
     public boolean mouseClicked(@NonNull MouseButtonEvent event, boolean doubleClick) {
-        if (!isAvailable() || event.button() != 0 || !isHoveredSliderBounds(event.x(), event.y()))
+        if (!isAvailable() || event.button() != InputConstants.MOUSE_BUTTON_LEFT || !isHoveredSliderBounds(event.x(), event.y()))
             return false;
 
         mouseDown = true;
@@ -78,7 +78,7 @@ public class SliderControllerElement extends ControllerWidget<ISliderController<
 
     @Override
     public boolean mouseDragged(@NonNull MouseButtonEvent event, double dx, double dy) {
-        if (!isAvailable() || event.button() != 0 || !mouseDown)
+        if (!isAvailable() || event.button() != InputConstants.MOUSE_BUTTON_LEFT || !mouseDown)
             return false;
 
         setValueFromMouse(event.x());


### PR DESCRIPTION
I ran into the same issue as #348 with sliders when testing my mod on 26.3.

In 26.3-snapshot-4, we get "unified" mouse device input numbering (mapping left click to 1 instead of 0). 
I saw the slider component had these buttons hard-coded, and searched the code to find that the cycling controller was the only other place the code hardcoded 0 and 1 for left and right buttons.

I swapped these hardcoded integers out for `InputConstants.MOUSE_BUTTON_LEFT` and `InputConstants.MOUSE_BUTTON_RIGHT` like I saw in OptionListWidget and YACLScreen. Now they work great on Fabric 26.3. I assume since there's no Stonecutter branching in those scenarios, and the rest of the code already relies on these constants working fine across all  versions, then there's virtually zero risk of this breaking anything on older versions.