### PR TITLE
Update NeoForge properties

### DIFF
--- a/src/main/templates/META-INF/mods.toml
+++ b/src/main/templates/META-INF/mods.toml
@@ -1,12 +1,13 @@
 modLoader = "javafml"
 loaderVersion = "${loaderVersion}"
-#issueTrackerURL = ""
+issueTrackerURL = "https://github.com/${github}/issues"
 license = "${mod_license}"
 
 [[mods]]
 modId = "${mod_id}"
 version = "${mod_version}"
 displayName = "${mod_name}"
+displayURL = "https://isxander.dev"
 authors = "${mod_author}"
 description = '''
 ${mod_description}

--- a/src/main/templates/META-INF/mods.toml
+++ b/src/main/templates/META-INF/mods.toml
@@ -11,17 +11,17 @@ authors = "${mod_author}"
 description = '''
 ${mod_description}
 '''
-logoFile = "yacl-128x.png"
+iconFile = "yacl-128x.png"
 
 [["dependencies.${mod_id}"]]
 modId = "forge"
-mandatory = true
+type = "required"
 ordering = "NONE"
 side = "BOTH"
 
 [["dependencies.${mod_id}"]]
 modId = "minecraft"
-mandatory = true
+type = "required"
 versionRange = "${mc}"
 ordering = "NONE"
 side = "BOTH"

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -1,12 +1,13 @@
 modLoader = "javafml"
 loaderVersion = "[1,)"
-#issueTrackerURL = ""
+issueTrackerURL = "https://github.com/${github}/issues"
 license = "${mod_license}"
 
 [[mods]]
 modId = "${mod_id}"
 version = "${mod_version}"
 displayName = "${mod_name}"
+displayURL = "https://isxander.dev"
 authors = "${mod_author}"
 description = '''
 ${mod_description}

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -11,18 +11,18 @@ authors = "${mod_author}"
 description = '''
 ${mod_description}
 '''
-logoFile = "yacl-128x.png"
+iconFile = "yacl-128x.png"
 
 [["dependencies.${mod_id}"]]
 modId = "neoforge"
-mandatory = true
+type = "required"
 versionRange = "${loaderVersion}"
 ordering = "NONE"
 side = "BOTH"
 
 [["dependencies.${mod_id}"]]
 modId = "minecraft"
-mandatory = true
+type = "required"
 versionRange = "${mc}"
 ordering = "NONE"
 side = "BOTH"


### PR DESCRIPTION
This pull request aims to update some properties in the NeoForge metadata files to use non-deprecated properties, fixing issues like the screenshot below, and to achieve better URL parity with the `fabric.mod.json` file.

Changes made:
- `logoFile` has been changed to `iconFile`, see screenshot below and neoforged/NeoForge#3073.
- `mandatory` has been changed to `type`, see neoforged/FancyModLoader#51.
- `issueTrackerURL` has been uncommented which points to the same URL as Fabric's `issues` URL.
- `displayURL` has been added which points to the same URL as Fabric's `homepage` URL.

Note: I haven't tested the `iconFile` change to see if it still resolves to the correct location. Although, I'm sure it still does!

Screenshot of issue:
![NeoForge's warning screen describing YACL's use of deprecated `logoFile` property.](https://github.com/user-attachments/assets/2fee93f9-ed17-4076-9af0-a06e317ec2e0)